### PR TITLE
MIR-552 use i18n key for empty select option

### DIFF
--- a/mir-module/src/main/resources/xsl/xeditor-mir-templates.xsl
+++ b/mir-module/src/main/resources/xsl/xeditor-mir-templates.xsl
@@ -208,10 +208,7 @@
       <xsl:apply-templates select="." mode="inputOptions" />
       <xsl:if test="not(@inlcudeOnly = 'true')">
         <option value="">
-          <xed:multi-lang>
-            <xed:lang xml:lang="de">(bitte wählen)</xed:lang>
-            <xed:lang xml:lang="en">(please select)</xed:lang>
-          </xed:multi-lang>
+          <xed:output i18n="mir.select" />
         </option>
       </xsl:if>
       <xed:include uri="{@uri}" />


### PR DESCRIPTION
- replaced german and english text with i18n key (mir.select)