### PR TITLE
MIR-573 URN Resolver URL does not redirect directly

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -86,7 +86,7 @@ MCR.IndexBrowser.cproceeding_sub.Table=mods
   MCR.Handle.Resolver.MasterURL=http://hdl.handle.net/
 
 # URL of the URN master resolver at Deutsche Bibliothek
-  MCR.URN.Resolver.MasterURL=http://nbn-resolving.org/
+  MCR.URN.Resolver.MasterURL=http://nbn-resolving.de/
 
 # URL for local redirects to registered documents
   MCR.URN.Resolver.DocumentURL=receive/


### PR DESCRIPTION
 changed nbn-resolving.org to nbn-resolving.de