### PR TITLE
MIR-543 missing runtime dependency to jbig2-imageio

### DIFF
--- a/mir-module/pom.xml
+++ b/mir-module/pom.xml
@@ -111,6 +111,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.levigo.jbig2</groupId>
+      <artifactId>levigo-jbig2-imageio</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.7.201606060606</version>
         <executions>
           <execution>
             <goals>
@@ -580,6 +579,12 @@
         <groupId>org.mycore</groupId>
         <artifactId>mycore-wfc</artifactId>
         <version>${mycore.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.levigo.jbig2</groupId>
+        <artifactId>levigo-jbig2-imageio</artifactId>
+        <version>2.0</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
Add levigo-jbig2-imageio as runtime dependency