### PR TITLE
MCR-1649 move properties to mir-module

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -149,7 +149,7 @@ MCR.Module-solr.Indexer.BulkSize=25
 ##############################################################################
 # URIResolver & ContentTransformer                                           #
 ##############################################################################
-MCR.ContentTransformer.mycoreobject-solrdocument.Stylesheet=xsl/mir-solrbase.xsl
+MCR.LayoutTransformerFactory.Default.Ignore=%MCR.LayoutTransformerFactory.Default.Ignore%,classificationBrowserData-bootstrap,classificationBrowserData-roleSubselect
 MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-document%,mir-solr.xsl
 MCR.URIResolver.xslIncludes.mods=%MCR.URIResolver.xslIncludes.mods%,mods2mods-classmapping.xsl
 MCR.URIResolver.xslIncludes.mycoreobjectXML=%MCR.URIResolver.xslIncludes.mycoreobjectXML%,embargofilter.xsl
@@ -158,15 +158,21 @@ MCR.URIResolver.xslIncludes.solrResponse=%MCR.URIResolver.xslIncludes.solrRespon
 MCR.URIResolver.xslIncludes.xeditorTemplates=%MCR.URIResolver.xslIncludes.xeditorTemplates%,xeditor-mir-templates.xsl
 MIR.AVPlayer.Stylesheet=metadata/mir-video.js.xsl
 MCR.URIResolver.xslImports.modsmeta=metadata/mods-metadata-base.xsl,metadata/mir-browse.xsl,metadata/mir-breadcrumbs.xsl,metadata/mir-metadata-box.xsl,metadata/mir-admindata-box.xsl,metadata/mir-abstract.xsl,metadata/mir-collapse-files.xsl,metadata/mir-edit.xsl,metadata/mir-share.xsl,%MIR.AVPlayer.Stylesheet%,metadata/mir-viewer.xsl,metadata/mir-citation.xsl,metadata/mir-export.xsl,metadata/mir-history.xsl,metadata/mir-oastatistics.xsl
+MCR.ContentTransformer.source.Class=org.mycore.common.content.transformer.MCRToPrettyXML
 MCR.ContentTransformer.mycoreobject-rights.Stylesheet=xsl/metadata/mir-rights.xsl
 MCR.ContentTransformer.mycoreobject-modsmeta.Stylesheet=%MCR.ContentTransformer.mycoreobject-rights.Stylesheet%,xsl/metadata/mods-metadata.xsl
 MCR.ContentTransformer.mycoreobject.Stylesheet=%MCR.ContentTransformer.mycoreobject-modsmeta.Stylesheet%,xsl/metadata/mods-metadata-page.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
+MCR.ContentTransformer.mycoreobject-solrdocument.Stylesheet=xsl/mir-solrbase.xsl
+MCR.ContentTransformer.response.Stylesheet=%MCR.ContentTransformer.response.Stylesheet%,%MCR.LayoutTransformerFactory.Default.Stylesheets%
 MCR.ContentTransformer.response-browse.Stylesheet=xsl/response2mycoreobject.xsl,%MCR.ContentTransformer.mycoreobject.Stylesheet%
 MCR.ContentTransformer.response-browsedebug.Stylesheet=xsl/response2mycoreobject.xsl
 MCR.ContentTransformer.mods2xeditor.Stylesheet=xsl/editor/mods2xeditor.xsl
 
 MCR.ContentTransformer.response-subselect.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xsl/response.xsl,xsl/relatedItem-subselect.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
 MCR.ContentTransformer.response-resultlist.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xsl/response-resultlist.xsl
+
+MCR.Viewer.metadata.transformer = mycoreobject-viewer
+MCR.ContentTransformer.mycoreobject-viewer.Stylesheet=xsl/mycoreobject-mods.xsl,xsl/mods-pure-viewer.xsl
 
 
 ##############################################################################

--- a/mir-webapp/src/main/resources/mycore.properties
+++ b/mir-webapp/src/main/resources/mycore.properties
@@ -1,5 +1,0 @@
-MCR.LayoutTransformerFactory.Default.Ignore=%MCR.LayoutTransformerFactory.Default.Ignore%,classificationBrowserData-bootstrap,classificationBrowserData-roleSubselect
-MCR.ContentTransformer.response.Stylesheet=%MCR.ContentTransformer.response.Stylesheet%,%MCR.LayoutTransformerFactory.Default.Stylesheets%
-MCR.ContentTransformer.source.Class=org.mycore.common.content.transformer.MCRToPrettyXML
-MCR.Viewer.metadata.transformer = mycoreobject-viewer
-MCR.ContentTransformer.mycoreobject-viewer.Stylesheet=xsl/mycoreobject-mods.xsl,xsl/mods-pure-viewer.xsl


### PR DESCRIPTION
Old properties where in classpath. Support for this was dropped
whene MCR-1649 dropped mycore-complete support.