### PR TITLE
MIR-657 make OAI answers DINI conform and optimize for speed

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -15,6 +15,7 @@ MCR.CLI.Classes.External=%MCR.CLI.Classes.External%,org.mycore.mir.migration.MIR
 MCR.CLI.Classes.External=%MCR.CLI.Classes.External%,org.mycore.mir.migration.MIRMigration2016_03
 MCR.CLI.Classes.External=%MCR.CLI.Classes.External%,org.mycore.mir.migration.MIRMigration2017_06
 
+MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xsl/mods2mods.xsl,xsl/mods2dc.xsl
 
 ##############################################################################
 # Configure ACL Checking                                                     #

--- a/mir-module/src/main/resources/xsl/mcr_directory-recursive.xsl
+++ b/mir-module/src/main/resources/xsl/mcr_directory-recursive.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="copynodes.xsl" />
+  <xsl:template match="numChildren" />
+  <xsl:template match="child[@type='directory']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+      <path xml:space="preserve">
+        <xsl:value-of select="concat(substring-after(substring-after(uri, ':'), ':'),'/')" />
+        <xsl:variable name="derId" select="substring-before(substring-after(uri,':/'), ':')" />
+        <xsl:variable name="filePath" select="substring-after(substring-after(uri, ':'), ':')" />
+        <xsl:variable name="suburi" select="concat('ifs:',$derId,$filePath)" />
+        <xsl:apply-templates select="document($suburi)/mcr_directory/children/child" />
+      </path>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/mir-module/src/main/resources/xsl/mods2dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2dc.xsl
@@ -315,6 +315,7 @@
     match="mods:dateIssued[@point='start'] | mods:dateCreated[@point='start'] | mods:dateCaptured[@point='start'] | mods:dateOther[@point='start'] ">
     <xsl:variable name="dateName" select="local-name()"/>
     <dc:date>
+      <!-- for ranges see: http://dublincore.org/documents/date-element/ -->
       <xsl:value-of select="concat(., '/', ../*[local-name()=$dateName and @point='end'])" />
     </dc:date>
   </xsl:template>

--- a/mir-module/src/main/resources/xsl/mods2dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2dc.xsl
@@ -94,10 +94,8 @@
             <xsl:apply-templates select="mods:classification" />
             <xsl:apply-templates select="mods:subject" />
             <xsl:apply-templates select="mods:abstract" />
+            <xsl:apply-templates select="." mode="dc_date" />
             <xsl:apply-templates select="mods:originInfo" />
-            <xsl:apply-templates select="mods:dateIssued" />
-            <xsl:apply-templates select="mods:dateCreated" />
-            <xsl:apply-templates select="mods:dateCaptured" />
             <xsl:apply-templates select="mods:temporal" />
             <xsl:apply-templates select="mods:physicalDescription" />
             <xsl:apply-templates select="mods:language" />
@@ -271,37 +269,45 @@
   </xsl:template>
 
   <xsl:template match="mods:originInfo">
-    <xsl:apply-templates select="*[@point='start']"/>
-    <xsl:for-each
-      select="mods:dateIssued[@point!='start' and @point!='end'] |mods:dateCreated[@point!='start' and @point!='end'] | mods:dateCaptured[@point!='start' and @point!='end'] | mods:dateOther[@point!='start' and @point!='end']">
-      <dc:date>
-        <xsl:value-of select="."/>
-      </dc:date>
-    </xsl:for-each>
-    <xsl:apply-templates select="*[not(@point)]"/>
-
     <xsl:for-each select="mods:publisher">
       <dc:publisher>
         <xsl:value-of select="."/>
       </dc:publisher>
     </xsl:for-each>
-
+  </xsl:template>
+  
+  <xsl:template match="mods:mods" mode="dc_date">
+    <xsl:choose>
+      <xsl:when test="mods:originInfo/mods:dateIssued[@point='start']">
+        <xsl:apply-templates select="mods:originInfo/mods:dateIssued[@point='start']" />
+      </xsl:when>
+      <xsl:when test="mods:originInfo/mods:dateIssued">
+        <xsl:apply-templates select="mods:originInfo/mods:dateIssued[1]" />
+      </xsl:when>
+      <xsl:when test="mods:originInfo/mods:dateCreated[@point='start']">
+        <xsl:apply-templates select="mods:originInfo/mods:dateCreated[@point='start']" />
+      </xsl:when>
+      <xsl:when test="mods:originInfo/mods:dateCreated">
+        <xsl:apply-templates select="mods:originInfo/mods:dateCreated[1]" />
+      </xsl:when>
+      <xsl:when test="mods:originInfo/mods:dateCaptured[@point='start']">
+        <xsl:apply-templates select="mods:originInfo/mods:dateCaptured[@point='start']" />
+      </xsl:when>
+      <xsl:when test="mods:originInfo/mods:dateCaptured">
+        <xsl:apply-templates select="mods:originInfo/mods:dateCaptured[1]" />
+      </xsl:when>
+      <xsl:otherwise>
+        <dc:date>
+          <xsl:comment>metadata creation date</xsl:comment>
+          <xsl:value-of select="substring-before(../../../../service/servdates/servdate[@type='createdate'],'T')" />
+        </dc:date>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured">
     <dc:date>
-      <xsl:choose>
-        <xsl:when test="@point='start'">
-          <xsl:value-of select="."/>
-          <xsl:text> - </xsl:text>
-        </xsl:when>
-        <xsl:when test="@point='end'">
-          <xsl:value-of select="."/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="."/>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:value-of select="."/>
     </dc:date>
   </xsl:template>
 
@@ -309,8 +315,7 @@
     match="mods:dateIssued[@point='start'] | mods:dateCreated[@point='start'] | mods:dateCaptured[@point='start'] | mods:dateOther[@point='start'] ">
     <xsl:variable name="dateName" select="local-name()"/>
     <dc:date>
-      <xsl:value-of select="."/>-<xsl:value-of
-        select="../*[local-name()=$dateName][@point='end']"/>
+      <xsl:value-of select="concat(., '/', ../*[local-name()=$dateName and @point='end'])" />
     </dc:date>
   </xsl:template>
 

--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -203,7 +203,7 @@
         </xsl:choose>
       </xsl:attribute>
       <xsl:apply-templates mode="mods.title" select="." />
-    </dc:title>>
+    </dc:title>
 
     <xsl:if test="mods:titleInfo[@type='translated']">
       <dc:title xsi:type="ddb:titleISO639-2" ddb:type="translated">

--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -2,52 +2,78 @@
 <!-- ============================================== -->
 <!-- $Revision: 1.8 $ $Date: 2007-04-20 15:18:23 $ -->
 <!-- ============================================== -->
-<xsl:stylesheet
-     version="1.0"
-     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-     xmlns:xlink="http://www.w3.org/1999/xlink"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xmlns:exslt="http://exslt.org/common"
-     xmlns:mods="http://www.loc.gov/mods/v3"
-     xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
-     xmlns:piUtil="xalan://org.mycore.mir.pi.MCRPIUtil"
-     xmlns:cmd="http://www.cdlib.org/inside/diglib/copyrightMD"
+<xsl:stylesheet 
+  version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:exslt="http://exslt.org/common"
+  xmlns:mods="http://www.loc.gov/mods/v3"
+  xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
+  xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
+  xmlns:xalan="http://xml.apache.org/xalan"
 
-     xmlns:gndo="http://d-nb.info/standards/elementset/gnd#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:cmd="http://www.cdlib.org/inside/diglib/copyrightMD"
+  xmlns:gndo="http://d-nb.info/standards/elementset/gnd#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:xMetaDiss="http://www.d-nb.de/standards/xmetadissplus/"
+  xmlns:cc="http://www.d-nb.de/standards/cc/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcmitype="http://purl.org/dc/dcmitype/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:pc="http://www.d-nb.de/standards/pc/"
+  xmlns:urn="http://www.d-nb.de/standards/urn/"
+  xmlns:thesis="http://www.ndltd.org/standards/metadata/etdms/1.0/"
+  xmlns:ddb="http://www.d-nb.de/standards/ddb/"
+  xmlns:dini="http://www.d-nb.de/standards/xmetadissplus/type/"
+  xmlns:sub="http://www.d-nb.de/standards/subject/"
 
-     xmlns:xMetaDiss="http://www.d-nb.de/standards/xmetadissplus/"
-     xmlns:cc="http://www.d-nb.de/standards/cc/"
-     xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:dcmitype="http://purl.org/dc/dcmitype/"
-     xmlns:dcterms="http://purl.org/dc/terms/"
-     xmlns:pc="http://www.d-nb.de/standards/pc/"
-     xmlns:urn="http://www.d-nb.de/standards/urn/"
-     xmlns:thesis="http://www.ndltd.org/standards/metadata/etdms/1.0/"
-     xmlns:ddb="http://www.d-nb.de/standards/ddb/"
-     xmlns:dini="http://www.d-nb.de/standards/xmetadissplus/type/"
-     xmlns="http://www.d-nb.de/standards/subject/"
-
-     exclude-result-prefixes="cc dc dcmitype dcterms pc urn thesis ddb dini xlink exslt mods i18n xsl gndo rdf cmd piUtil"
-     xsi:schemaLocation="http://www.d-nb.de/standards/xmetadissplus/  http://files.dnb.de/standards/xmetadissplus/xmetadissplus.xsd">
+  exclude-result-prefixes="xalan mcrxsl cc dc dcmitype dcterms pc urn thesis ddb dini xlink exslt mods i18n xsl gndo rdf cmd"
+  xsi:schemaLocation="http://www.d-nb.de/standards/xmetadissplus/  http://files.dnb.de/standards/xmetadissplus/xmetadissplus.xsd">
 
   <xsl:output method="xml" encoding="UTF-8" />
 
   <xsl:include href="mods2record.xsl" />
   <xsl:include href="mods-utils.xsl" />
-  <xsl:include href="coreFunctions.xsl"/>
 
   <xsl:param name="ServletsBaseURL" select="''" />
   <xsl:param name="WebApplicationBaseURL" select="''" />
   <xsl:param name="MCR.OAIDataProvider.RepositoryPublisherName" select="''" />
   <xsl:param name="MCR.OAIDataProvider.RepositoryPublisherPlace" select="''" />
   <xsl:param name="MCR.OAIDataProvider.RepositoryPublisherAddress" select="''" />
+  <xsl:param name="MCR.Metadata.DefaultLang" select="''" />
+
+  <xsl:variable name="languages" select="document('classification:metadata:-1:children:rfc4646')" />
+  <xsl:variable name="marcrelator" select="document('classification:metadata:-1:children:marcrelator')" />
+
+  <xsl:key name="contentType" match="child" use="contentType" />
+  <xsl:key name="category" match="category" use="@ID" />
 
   <xsl:variable name="language">
-    <xsl:call-template name="translate_Lang">
-      <xsl:with-param name="lang_code" select="//metadata/def.modsContainer/modsContainer/mods:mods/mods:language/mods:languageTerm[@authority='rfc4646']/text()" />
-    </xsl:call-template>
+    <xsl:variable name="lang"
+      select="/mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:language/mods:languageTerm[@authority='rfc4646']/text()" />
+    <xsl:choose>
+      <xsl:when test="$lang">
+        <xsl:call-template name="translate_Lang">
+          <xsl:with-param name="lang_code" select="$lang" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="translate_Lang">
+          <xsl:with-param name="lang_code" select="$MCR.Metadata.DefaultLang" />
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:variable>
+
+  <xsl:variable name="ifsTemp">
+    <xsl:for-each select="mycoreobject/structure/derobjects/derobject[mcrxsl:isDisplayedEnabledDerivate(@xlink:href)]">
+      <der id="{@xlink:href}">
+        <xsl:copy-of select="document(concat('xslStyle:mcr_directory-recursive:ifs:',@xlink:href,'/'))" />
+      </der>
+    </xsl:for-each>
+  </xsl:variable>
+  <xsl:variable name="ifs" select="xalan:nodeset($ifsTemp)" />
 
   <xsl:template match="mycoreobject" mode="metadata">
 
@@ -62,691 +88,585 @@
                                xmlns:thesis=&quot;http://www.ndltd.org/standards/metadata/etdms/1.0/&quot;
                                xmlns:ddb=&quot;http://www.d-nb.de/standards/ddb/&quot;
                                xmlns:dini=&quot;http://www.d-nb.de/standards/xmetadissplus/type/&quot;
-                               xmlns=&quot;http://www.d-nb.de/standards/subject/&quot;
+                               xmlns:sub=&quot;http://www.d-nb.de/standards/subject/&quot;
                                xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
                                xsi:schemaLocation=&quot;http://www.d-nb.de/standards/xmetadissplus/
                                http://files.dnb.de/standards/xmetadissplus/xmetadissplus.xsd&quot;&#62;
     </xsl:text>
+    <xsl:variable name="mods" select="metadata/def.modsContainer/modsContainer/mods:mods" />
 
-
-             <xsl:call-template name="title" />
-             <xsl:call-template name="alternative" />
-             <xsl:call-template name="creator" />
-             <xsl:call-template name="subject" />
-             <xsl:call-template name="abstract" />
-             <xsl:call-template name="repositoryPublisher" />
-             <xsl:call-template name="contributor" />
-             <xsl:call-template name="date" />
-             <xsl:call-template name="type" />
-             <xsl:call-template name="identifier" />
-             <xsl:call-template name="format" />
-             <xsl:call-template name="publisher" />
-             <xsl:call-template name="relatedItem2source" />
-             <xsl:call-template name="language" />
-             <xsl:call-template name="relatedItem2ispartof" />
-             <xsl:call-template name="degree" />
-             <xsl:call-template name="contact" />
-             <xsl:call-template name="file" />
-             <xsl:call-template name="frontpage" />
-             <xsl:call-template name="rights" />
+    <xsl:apply-templates select="$mods" mode="title" />
+    <xsl:apply-templates select="$mods" mode="alternative" />
+    <xsl:apply-templates select="$mods" mode="creator" />
+    <xsl:apply-templates select="$mods" mode="subject" />
+    <xsl:apply-templates select="$mods" mode="abstract" />
+    <xsl:apply-templates select="$mods" mode="repositoryPublisher" />
+    <xsl:apply-templates select="$mods" mode="contributor" />
+    <xsl:apply-templates select="$mods" mode="date" />
+    <xsl:apply-templates select="$mods" mode="type" />
+    <xsl:apply-templates select="$mods" mode="identifier" />
+    <xsl:apply-templates select="$mods" mode="format" />
+    <xsl:apply-templates select="$mods" mode="publisher" />
+    <xsl:apply-templates select="$mods" mode="relatedItem2source" />
+    <xsl:call-template name="language" />
+    <xsl:apply-templates select="$mods" mode="relatedItem2ispartof" />
+    <xsl:apply-templates select="$mods" mode="degree" />
+    <xsl:call-template name="file" />
+    <xsl:apply-templates select="." mode="frontpage" />
+    <xsl:call-template name="rights" />
     <xsl:text disable-output-escaping="yes">
       &#60;/xMetaDiss:xMetaDiss&#62;
-      </xsl:text>
-    </xsl:template>
+    </xsl:text>
+  </xsl:template>
 
-    <xsl:template name="linkQueryURL">
-        <xsl:param name="id"/>
-        <xsl:value-of select="concat('mcrobject:',$id)" />
-    </xsl:template>
+  <xsl:template name="linkQueryURL">
+    <xsl:param name="id" />
+    <xsl:value-of select="concat('mcrobject:',$id)" />
+  </xsl:template>
 
-    <xsl:template name="lang">
-      <xsl:choose>
-        <xsl:when test="./@xml:lang or string-length(./@xml:lang) &gt; 0">
-          <xsl:variable name="myURI" select="concat('classification:metadata:0:children:rfc4646:',./@xml:lang)" />
-          <xsl:value-of select="document($myURI)//label[@xml:lang='x-bibl']/@text" />
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$language" />
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:template>
-
-    <xsl:template name="translate_Lang">
-      <xsl:param name="lang_code" />
-      <xsl:variable name="myURI" select="concat('classification:metadata:0:children:rfc4646:',$lang_code)" />
-      <xsl:value-of select="document($myURI)//label[@xml:lang='x-bibl']/@text"/>
-    </xsl:template>
-
-    <xsl:template name="replaceSubSupTags">
-        <xsl:param name="content" select="''" />
-        <xsl:choose>
-           <xsl:when test="contains($content,'&lt;sub&gt;')">
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-before($content,'&lt;sub&gt;')" />
-              </xsl:call-template>
-              <xsl:text>_</xsl:text>
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-after($content,'&lt;sub&gt;')" />
-              </xsl:call-template>
-           </xsl:when>
-           <xsl:when test="contains($content,'&lt;/sub&gt;')">
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-before($content,'&lt;/sub&gt;')" />
-              </xsl:call-template>
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-after($content,'&lt;/sub&gt;')" />
-              </xsl:call-template>
-           </xsl:when>
-           <xsl:when test="contains($content,'&lt;sup&gt;')">
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-before($content,'&lt;sup&gt;')" />
-              </xsl:call-template>
-              <xsl:text>^</xsl:text>
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-after($content,'&lt;sup&gt;')" />
-              </xsl:call-template>
-           </xsl:when>
-           <xsl:when test="contains($content,'&lt;/sup&gt;')">
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-before($content,'&lt;/sup&gt;')" />
-              </xsl:call-template>
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="substring-after($content,'&lt;/sup&gt;')" />
-              </xsl:call-template>
-           </xsl:when>
-           <xsl:otherwise>
-               <xsl:value-of select="$content" />
-           </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-    <xsl:template name="title">
-      <xsl:element name="dc:title">
-         <xsl:attribute name="lang">
-           <xsl:choose>
-             <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:titleInfo[not(@type='uniform' or @type='abbreviated' or @type='alternative' or @type='translated')]/@xml:lang">
-               <xsl:call-template name="translate_Lang">
-                 <xsl:with-param name="lang_code" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:titleInfo[not(@type='uniform' or @type='abbreviated' or @type='alternative' or @type='translated')]/@xml:lang" />
-               </xsl:call-template>
-             </xsl:when>
-             <xsl:otherwise>
-               <xsl:value-of select="$language" />
-             </xsl:otherwise>
-           </xsl:choose>
-         </xsl:attribute>
-         <xsl:attribute name="xsi:type">ddb:titleISO639-2</xsl:attribute>
-         <xsl:apply-templates mode="mods.title" select="./metadata/def.modsContainer/modsContainer/mods:mods" />
-      </xsl:element>
-
-      <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:titleInfo[@type='translated']">
-        <xsl:element name="dc:title">
-           <xsl:attribute name="lang">
-             <xsl:call-template name="translate_Lang">
-               <xsl:with-param name="lang_code" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:titleInfo[@type='translated']/@xml:lang" />
-             </xsl:call-template>
-           </xsl:attribute>
-           <xsl:attribute name="ddb:type">translated</xsl:attribute>
-           <xsl:attribute name="xsi:type">ddb:titleISO639-2</xsl:attribute>
-           <xsl:apply-templates mode="mods.title" select="./metadata/def.modsContainer/modsContainer/mods:mods">
-             <xsl:with-param name="type" select="'translated'" />
-           </xsl:apply-templates>
-        </xsl:element>
-      </xsl:if>
-    </xsl:template>
-
-    <xsl:template name="alternative">
-       <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:titleInfo/mods:title[@type='uniform' or @type='abbreviated' or @type='alternative']">
-           <xsl:element name="dcterms:alternative">
-               <xsl:attribute name="lang">
-                 <xsl:call-template name="translate_Lang">
-                   <xsl:with-param name="lang_code" select="../@xml:lang" />
-                 </xsl:call-template>
-               </xsl:attribute>
-               <xsl:attribute name="xsi:type">ddb:talternativeISO639-2</xsl:attribute>
-               <xsl:value-of select="." />
-               <xsl:if test="../mods.subtitle">
-                 <xsl:text> : </xsl:text>
-                 <xsl:value-of select="../mods.subtitle" />
-               </xsl:if>
-           </xsl:element>
-       </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="creator">
-      <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='aut']">
-        <xsl:element name="dc:creator">
-          <xsl:attribute name="xsi:type">pc:MetaPers</xsl:attribute>
-          <xsl:element name="pc:person">
-            <xsl:if test="mods:nameIdentifier[@type='gnd']">
-              <xsl:attribute name="PND-Nr">
-                <xsl:value-of select="mods:nameIdentifier[@type='gnd']" />
-              </xsl:attribute>
-            </xsl:if>
-            <xsl:element name="pc:name">
-              <xsl:choose>
-                <xsl:when test="@type='corporate'">
-                  <xsl:attribute name="type">otherName</xsl:attribute>
-                  <xsl:attribute name="otherNameType">organisation</xsl:attribute>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:attribute name="type">nameUsedByThePerson</xsl:attribute>
-                </xsl:otherwise>
-              </xsl:choose>
-              <xsl:choose>
-                <xsl:when test="@type='corporate'">
-                  <xsl:element name="pc:organisationName">
-                    <xsl:value-of select="mods:displayForm" />
-                  </xsl:element>
-                </xsl:when>
-                <xsl:when test="mods:nameIdentifier[@type='gnd']">
-                  <xsl:variable name="gndURL" select="concat('http://d-nb.info/gnd/',normalize-space(mods:nameIdentifier[@type='gnd']),'/about/lds.rdf')" />
-                  <xsl:variable name="gndEntry" select="document($gndURL)" />
-                  <xsl:element name="pc:foreName">
-                    <xsl:value-of select="$gndEntry//gndo:preferredNameEntityForThePerson/rdf:Description/gndo:forename" />
-                  </xsl:element>
-                  <xsl:element name="pc:surName">
-                    <xsl:value-of select="$gndEntry//gndo:preferredNameEntityForThePerson/rdf:Description/gndo:surname" />
-                  </xsl:element>
-                </xsl:when>
-                <xsl:when test="contains(mods:displayForm, ',')">
-                  <xsl:element name="pc:foreName">
-                    <xsl:value-of select="normalize-space(substring-after(mods:displayForm,','))" />
-                  </xsl:element>
-                  <xsl:element name="pc:surName">
-                    <xsl:value-of select="normalize-space(substring-before(mods:displayForm,','))" />
-                  </xsl:element>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:element name="pc:personEnteredUnderGivenName">
-                    <xsl:value-of select="mods:displayForm" />
-                  </xsl:element>
-                </xsl:otherwise>
-              </xsl:choose>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="subject">
-      <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[@authority='sdnb']">
-        <xsl:element name="dc:subject">
-          <xsl:attribute name="xsi:type">xMetaDiss:DDC-SG</xsl:attribute>
-          <xsl:value-of select="." />
-        </xsl:element>
-      </xsl:for-each>
-
-       <!-- xsl:for-each select="./metadata/keywords/keyword[@type='SWD']">
-           <xsl:element name="dc:subject">
-               <xsl:attribute name="xsi:type">xMetaDiss:SWD</xsl:attribute>
-               <xsl:value-of select="." />
-           </xsl:element>
-       </xsl:for-each -->
-        <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:subject">
-           <xsl:element name="dc:subject">
-               <xsl:attribute name="xsi:type">xMetaDiss:noScheme</xsl:attribute>
-               <xsl:value-of select="mods:topic" />
-           </xsl:element>
-       </xsl:for-each>
-    </xsl:template>
-
-
-
-    <xsl:template name="abstract">
-      <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:abstract[not(@altFormat)]">
-          <xsl:element name="dcterms:abstract">
-              <xsl:attribute name="lang"><xsl:call-template name="lang" /></xsl:attribute>
-              <xsl:attribute name="xsi:type">ddb:contentISO639-2</xsl:attribute>
-              <xsl:call-template name="replaceSubSupTags">
-                  <xsl:with-param name="content" select="." />
-              </xsl:call-template>
-          </xsl:element>
-      </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="publisher">
-      <xsl:variable name="publisher_name">
-        <xsl:choose>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher" />
-          </xsl:when>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='pbl']">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='pbl']/mods:displayForm" />
-          </xsl:when>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:accessCondition[@type='copyrightMD']/cmd:copyright/cmd:rights.holder/cmd:name">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:accessCondition[@type='copyrightMD']/cmd:copyright/cmd:rights.holder/cmd:name" />
-          </xsl:when>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher" />
-          </xsl:when>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:name[mods:role/mods:roleTerm/text()='pbl']">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:name[mods:role/mods:roleTerm/text()='pbl']/mods:displayForm" />
-          </xsl:when>
-        </xsl:choose>
-      </xsl:variable>
-      <xsl:variable name="publisher_place">
-        <xsl:choose>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
-          </xsl:when>
-          <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']">
-            <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
-          </xsl:when>
-        </xsl:choose>
-      </xsl:variable>
-      <xsl:if test="string-length($publisher_name) &gt; 0">
-        <xsl:choose>
-          <xsl:when test="string-length($publisher_place) &gt; 0">
-            <dc:source xsi:type="ddb:noScheme"><xsl:value-of select="concat($publisher_place,' : ',$publisher_name)" /></dc:source>
-          </xsl:when>
-          <xsl:otherwise>
-            <dc:source xsi:type="ddb:noScheme"><xsl:value-of select="$publisher_name" /></dc:source>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:if>
-    </xsl:template>
-
-
-    <xsl:template name="repositoryPublisher">
-      <xsl:choose>
-        <xsl:when test="//mods:mods/mods:originInfo[@eventType='publication']/mods:publisher and //mods:mods/mods:originInfo[@eventType='publication']/mods:place/mods:placeTerm[@type='text']">
-          <xsl:call-template name="repositoryPublisherElement">
-            <xsl:with-param name="name" select="//mods:mods/mods:originInfo[@eventType='publication']/mods:publisher" />
-            <xsl:with-param name="place" select="//mods:mods/mods:originInfo[@eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
-            <xsl:with-param name="address" select="''" />
-          </xsl:call-template>
-        </xsl:when>
-        <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='his' and @valueURI]">
-          <xsl:variable name="insti" select="substring-after(./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='his' and @valueURI]/@valueURI, '#')"/>
-          <xsl:variable name="myURI" select="concat('classification:metadata:0:parents:mir_institutes:',$insti)" />
-          <xsl:variable name="cat" select="document($myURI)//category[@ID=$insti]/ancestor-or-self::category[label[lang('x-place')]][1]" />
-          <xsl:variable name="place" select="$cat/label[@xml:lang='x-place']/@text" />
-          <xsl:choose>
-            <xsl:when test="$place">
-              <xsl:variable name="placeArray">
-                <xsl:call-template name="Tokenizer"><!-- use split function from mycore-base/coreFunctions.xsl -->
-                  <xsl:with-param name="string" select="$place" />
-                  <xsl:with-param name="delimiter" select="'|'" />
-                </xsl:call-template>
-              </xsl:variable>
-              <xsl:variable name="placeSet" select="exslt:node-set($placeArray)/token" />
-              <xsl:variable name="address">
-                <xsl:choose>
-                  <xsl:when test="$placeSet[3]">
-                    <xsl:value-of select="$placeSet[3]" />
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="''" />
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable>
-              <xsl:call-template name="repositoryPublisherElement">
-                <xsl:with-param name="name" select="$placeSet[1]" />
-                <xsl:with-param name="place" select="$placeSet[2]" />
-                <xsl:with-param name="address" select="$address" />
-              </xsl:call-template>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:call-template name="repositoryPublisherElement">
-                <xsl:with-param name="name" select="$MCR.OAIDataProvider.RepositoryPublisherName" />
-                <xsl:with-param name="place" select="$MCR.OAIDataProvider.RepositoryPublisherPlace" />
-                <xsl:with-param name="address" select="$MCR.OAIDataProvider.RepositoryPublisherAddress" />
-              </xsl:call-template>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:call-template name="repositoryPublisherElement">
-            <xsl:with-param name="name" select="$MCR.OAIDataProvider.RepositoryPublisherName" />
-            <xsl:with-param name="place" select="$MCR.OAIDataProvider.RepositoryPublisherPlace" />
-            <xsl:with-param name="address" select="$MCR.OAIDataProvider.RepositoryPublisherAddress" />
-          </xsl:call-template>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:template>
-
-    <xsl:template name="repositoryPublisherElement">
-      <xsl:param name="name" />
-      <xsl:param name="place" />
-      <xsl:param name="address" />
-      <xsl:element name="dc:publisher">
-        <xsl:attribute name="xsi:type">cc:Publisher</xsl:attribute>
-        <xsl:attribute name="type">dcterms:ISO3166</xsl:attribute>
-        <xsl:attribute name="countryCode">DE</xsl:attribute>
-        <xsl:element name="cc:universityOrInstitution">
-          <xsl:element name="cc:name">
-            <xsl:value-of select="$name"/>
-          </xsl:element>
-          <xsl:element name="cc:place">
-            <xsl:value-of select="$place"/>
-          </xsl:element>
-          <cc:address cc:Scheme="DIN5008" />
-        </xsl:element>
-        <xsl:element name="cc:address">
-          <xsl:attribute name="cc:Scheme">DIN5008</xsl:attribute>
-          <xsl:value-of select="$address"/>
-        </xsl:element>
-      </xsl:element>
-    </xsl:template>
-
-    <xsl:template name="contributor">
-      <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:name[mods:role/mods:roleTerm/text()='ctb']"><!-- check subroles -->
-        <xsl:element name="dc:contributor">
-          <xsl:attribute name="xsi:type">pc:Contributor</xsl:attribute>
-          <!-- xsl:attribute name="thesis:role"><xsl:value-of select="./@type" /></xsl:attribute -->
-          <xsl:element name="pc:person">
-            <xsl:element name="pc:name">
-              <xsl:attribute name="type">nameUsedByThePerson</xsl:attribute>
-              <xsl:element name="pc:personEnteredUnderGivenName">
-                <xsl:value-of select="mods:displayForm" />
-              </xsl:element>
-            </xsl:element>
-          </xsl:element>
-        </xsl:element>
-      </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="date">
-      <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='creation']/mods:dateOther[@type='accepted'][@encoding='w3cdtf']">
-        <xsl:element name="dcterms:dateAccepted">
-          <xsl:attribute name="xsi:type">dcterms:W3CDTF</xsl:attribute>
-          <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='creation']/mods:dateOther[@type='accepted'][@encoding='w3cdtf']" />
-        </xsl:element>
-      </xsl:if>
-      <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='publication']/mods:dateIssued[@encoding='w3cdtf']">
-        <xsl:element name="dcterms:issued">
-          <xsl:attribute name="xsi:type">dcterms:W3CDTF</xsl:attribute>
-          <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='publication']/mods:dateIssued[@encoding='w3cdtf']" />
-        </xsl:element>
-      </xsl:if>
-      <xsl:for-each select="./service/servdates/servdate[@type='modifydate']">
-        <xsl:element name="dcterms:modified">
-          <xsl:attribute name="xsi:type">dcterms:W3CDTF</xsl:attribute>
-          <xsl:value-of select="." />
-        </xsl:element>
-      </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="type">
-      <xsl:element name="dc:type">
-        <xsl:attribute name="xsi:type">dini:PublType</xsl:attribute>
-        <xsl:choose>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:classification/@authorityURI,'diniPublType')">
-            <xsl:value-of select="substring-after(./metadata/def.modsContainer/modsContainer/mods:mods/mods:classification[contains(@authorityURI,'diniPublType')]/@valueURI,'diniPublType#')" />
-          </xsl:when>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'article')">
-            <xsl:text>contributionToPeriodical</xsl:text>
-          </xsl:when>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'issue')">
-            <xsl:text>PeriodicalPart</xsl:text>
-          </xsl:when>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'journal')">
-            <xsl:text>Periodical</xsl:text>
-          </xsl:when>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'book')">
-            <xsl:text>book</xsl:text>
-          </xsl:when>
-          <xsl:when test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'dissertation') or
-                          contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'habilitation')">
-            <xsl:text>doctoralThesis</xsl:text>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Other</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:element>
-      <xsl:element name="dc:type">
-        <xsl:attribute name="xsi:type">dcterms:DCMIType</xsl:attribute>
-        <xsl:text>Text</xsl:text>
-      </xsl:element>
-      <xsl:element name="dini:version_driver">
-        <xsl:text>publishedVersion</xsl:text>
-      </xsl:element>
-    </xsl:template>
-
-    <xsl:template name="identifier">
-      <xsl:variable name="piServiceInformation" select="piUtil:getPIServiceInformation(/mycoreobject/@ID)" />
-      <xsl:if test="$piServiceInformation[@type='dnbUrn'][@inscribed='true']">
-        <xsl:element name="dc:identifier">
-           <xsl:attribute name="xsi:type">urn:nbn</xsl:attribute>
-           <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:identifier[@type='urn']" />
-        </xsl:element>
-      </xsl:if>
-    </xsl:template>
-
-    <xsl:template name="format">
-      <xsl:for-each select="./structure/derobjects/derobject[1]">
-        <xsl:for-each select="document(concat('ifs:',./@xlink:href,'/'))/mcr_directory/children/child">
-          <xsl:choose>
-            <xsl:when test="contains(./contentType,'ps')">
-              <xsl:element name="dcterms:medium">
-                <xsl:attribute name="xsi:type">dcterms:IMT</xsl:attribute>
-                <xsl:text>application/postscript</xsl:text>
-              </xsl:element>
-            </xsl:when>
-            <xsl:when test="contains(./contentType,'pdf')">
-              <xsl:element name="dcterms:medium">
-                <xsl:attribute name="xsi:type">dcterms:IMT</xsl:attribute>
-                <xsl:text>application/pdf</xsl:text>
-              </xsl:element>
-            </xsl:when>
-            <xsl:when test="contains(./contentType,'audio/mpeg')">
-              <xsl:element name="dcterms:medium">
-                <xsl:attribute name="xsi:type">dcterms:IMT</xsl:attribute>
-                <xsl:text>audio/mpeg</xsl:text>
-              </xsl:element>
-            </xsl:when>
-            <xsl:when test="contains(./contentType,'audio/x-wav')">
-              <xsl:element name="dcterms:medium">
-                <xsl:attribute name="xsi:type">dcterms:IMT</xsl:attribute>
-                <xsl:text>audio/x-wav</xsl:text>
-              </xsl:element>
-            </xsl:when>
-            <xsl:when test="contains(./contentType,'zip')">
-              <xsl:element name="dcterms:medium">
-                <xsl:attribute name="xsi:type">dcterms:IMT</xsl:attribute>
-                <xsl:text>application/zip</xsl:text>
-              </xsl:element>
-            </xsl:when>
-          </xsl:choose>
-        </xsl:for-each>
-      </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template name="language">
-      <xsl:element name="dc:language">
-        <xsl:attribute name="xsi:type">dcterms:ISO639-2</xsl:attribute>
+  <xsl:template name="lang">
+    <xsl:choose>
+      <xsl:when test="@xml:lang">
+        <xsl:call-template name="translate_Lang">
+          <xsl:with-param name="lang_code" select="@xml:lang" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
         <xsl:value-of select="$language" />
-      </xsl:element>
-    </xsl:template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
+  <xsl:template name="translate_Lang">
+    <xsl:param name="lang_code" />
+    <xsl:for-each select="$languages">
+      <xsl:value-of select="key('category', $lang_code)/label[lang('x-bibl')]/@text" />
+    </xsl:for-each>
+  </xsl:template>
 
-    <xsl:template name="relatedItem2source">
-      <!--  If not use isPartOf use dc:source -->
-      <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem/@type='host'">
-        <xsl:variable name="hosttitel" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:titleInfo/mods:title" />
-        <xsl:variable name="issue" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']/mods:number"/>
-        <xsl:variable name="volume" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']/mods:number"/>
-        <xsl:variable name="startPage" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']/mods:start"/>
-        <xsl:variable name="endPage" select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']/mods:end"/>
-        <xsl:variable name="volume2">
-          <xsl:if test="string-length($volume) &gt; 0">
-            <xsl:value-of select="concat('(',$volume,')')"/>
-          </xsl:if>
-        </xsl:variable>
-        <xsl:variable name="issue2">
-          <xsl:if test="string-length($issue) &gt; 0">
-            <xsl:value-of select="concat(', H. ',$issue)"/>
-          </xsl:if>
-        </xsl:variable>
-        <xsl:variable name="pages">
-          <xsl:if test="string-length($startPage) &gt; 0">
-            <xsl:value-of select="concat(', S.',$startPage,'-',$endPage)"/>
-          </xsl:if>
-        </xsl:variable>
-        <dc:source xsi:type="ddb:noScheme">
-          <xsl:value-of select="concat($hosttitel,$volume2,$issue2,$pages)" />
-        </dc:source>
+  <xsl:template name="replaceSubSupTags">
+    <xsl:param name="content" select="''" />
+    <xsl:choose>
+      <xsl:when test="contains($content,'&lt;sub&gt;')">
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-before($content,'&lt;sub&gt;')" />
+        </xsl:call-template>
+        <xsl:text>_</xsl:text>
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-after($content,'&lt;sub&gt;')" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains($content,'&lt;/sub&gt;')">
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-before($content,'&lt;/sub&gt;')" />
+        </xsl:call-template>
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-after($content,'&lt;/sub&gt;')" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains($content,'&lt;sup&gt;')">
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-before($content,'&lt;sup&gt;')" />
+        </xsl:call-template>
+        <xsl:text>^</xsl:text>
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-after($content,'&lt;sup&gt;')" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains($content,'&lt;/sup&gt;')">
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-before($content,'&lt;/sup&gt;')" />
+        </xsl:call-template>
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="substring-after($content,'&lt;/sup&gt;')" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$content" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template mode="title" match="mods:mods">
+    <dc:title xsi:type="ddb:titleISO639-2">
+      <xsl:attribute name="lang">
+        <xsl:choose>
+          <xsl:when test="mods:titleInfo[not(@type='uniform' or @type='abbreviated' or @type='alternative' or @type='translated')]/@xml:lang">
+           <xsl:call-template name="translate_Lang">
+             <xsl:with-param name="lang_code"
+                select="mods:titleInfo[not(@type='uniform' or @type='abbreviated' or @type='alternative' or @type='translated')]/@xml:lang" />
+           </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$language" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:apply-templates mode="mods.title" select="." />
+    </dc:title>>
+
+    <xsl:if test="mods:titleInfo[@type='translated']">
+      <dc:title xsi:type="ddb:titleISO639-2" ddb:type="translated">
+        <xsl:attribute name="lang">
+        <xsl:call-template name="translate_Lang">
+          <xsl:with-param name="lang_code" select="mods:titleInfo[@type='translated']/@xml:lang" />
+        </xsl:call-template>
+        </xsl:attribute>
+        <xsl:apply-templates mode="mods.title" select="mods:mods">
+          <xsl:with-param name="type" select="'translated'" />
+        </xsl:apply-templates>
+      </dc:title>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template mode="alternative" match="mods:mods">
+    <xsl:for-each select="mods:titleInfo/mods:title[@type='uniform' or @type='abbreviated' or @type='alternative']">
+      <dcterms:alternative xsi:type="ddb:talternativeISO639-2">
+        <xsl:attribute name="lang">
+          <xsl:call-template name="translate_Lang">
+            <xsl:with-param name="lang_code" select="../@xml:lang" />
+          </xsl:call-template>
+        </xsl:attribute>
+        <xsl:value-of select="." />
+        <xsl:if test="../mods.subtitle">
+          <xsl:text> : </xsl:text>
+          <xsl:value-of select="../mods.subtitle" />
+        </xsl:if>
+      </dcterms:alternative>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="creator" match="mods:mods">
+    <xsl:variable name="creatorRoles" select="$marcrelator/mycoreclass/categories/category[@ID='cre']/descendant-or-self::category" />
+    <xsl:for-each select="mods:name[$creatorRoles/@ID=mods:role/mods:roleTerm/text()]">
+      <dc:creator xsi:type="pc:MetaPers">
+        <xsl:apply-templates select="." mode="pc-person" />
+      </dc:creator>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <xsl:template mode="pc-person" match="mods:name">
+    <pc:person>
+      <xsl:if test="mods:nameIdentifier[@type='gnd']">
+        <xsl:attribute name="PND-Nr">
+          <xsl:value-of select="mods:nameIdentifier[@type='gnd']" />
+        </xsl:attribute>
       </xsl:if>
-    </xsl:template>
+      <pc:name>
+        <xsl:choose>
+          <xsl:when test="@type='corporate'">
+            <xsl:attribute name="type">otherName</xsl:attribute>
+            <xsl:attribute name="otherNameType">organisation</xsl:attribute>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:attribute name="type">nameUsedByThePerson</xsl:attribute>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+          <xsl:when test="@type='corporate'">
+            <pc:organisationName>
+              <xsl:value-of select="mods:displayForm" />
+            </pc:organisationName>
+          </xsl:when>
+          <xsl:when test="contains(mods:displayForm, ',')">
+            <pc:foreName>
+              <xsl:value-of select="normalize-space(substring-after(mods:displayForm,','))" />
+            </pc:foreName>
+            <pc:surName>
+              <xsl:value-of select="normalize-space(substring-before(mods:displayForm,','))" />
+            </pc:surName>
+          </xsl:when>
+          <xsl:otherwise>
+            <pc:personEnteredUnderGivenName>
+              <xsl:value-of select="mods:displayForm" />
+            </pc:personEnteredUnderGivenName>
+          </xsl:otherwise>
+        </xsl:choose>
+      </pc:name>
+    </pc:person>
+  </xsl:template>
+
+  <xsl:template mode="subject" match="mods:mods">
+    <xsl:for-each select="mods:classification[@authority='sdnb']">
+      <dc:subject xsi:type="xMetaDiss:DDC-SG">
+        <xsl:value-of select="." />
+      </dc:subject>
+    </xsl:for-each>
+    <xsl:for-each select="mods:subject">
+      <dc:subject xsi:type="xMetaDiss:noScheme">
+        <xsl:value-of select="mods:topic" />
+      </dc:subject>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="abstract" match="mods:mods">
+    <xsl:for-each select="mods:abstract[not(@altFormat)]">
+      <dcterms:abstract xsi:type="ddb:contentISO639-2">
+        <xsl:attribute name="lang"><xsl:call-template name="lang" /></xsl:attribute>
+        <xsl:call-template name="replaceSubSupTags">
+          <xsl:with-param name="content" select="." />
+        </xsl:call-template>
+      </dcterms:abstract>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="publisher" match="mods:mods">
+    <xsl:variable name="publisherRoles" select="$marcrelator/mycoreclass/categories/category[@ID='pbl']/descendant-or-self::category" />
+    <xsl:variable name="publisher_name">
+      <xsl:choose>
+        <xsl:when test="mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher">
+          <xsl:value-of select="mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher" />
+        </xsl:when>
+        <xsl:when test="mods:name[$publisherRoles/@ID=mods:role/mods:roleTerm/text()]">
+          <xsl:value-of select="mods:name[mods:role/mods:roleTerm/text()='pbl']/mods:displayForm" />
+        </xsl:when>
+        <xsl:when test="mods:accessCondition[@type='copyrightMD']/cmd:copyright/cmd:rights.holder/cmd:name">
+          <xsl:value-of select="mods:accessCondition[@type='copyrightMD']/cmd:copyright/cmd:rights.holder/cmd:name" />
+        </xsl:when>
+        <xsl:when test="mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher">
+          <xsl:value-of
+            select="mods:mods/mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:publisher" />
+        </xsl:when>
+        <xsl:when test="mods:relatedItem[@type='host']/mods:name[mods:role/mods:roleTerm/text()='pbl']">
+          <xsl:value-of select="mods:relatedItem[@type='host']/mods:name[mods:role/mods:roleTerm/text()='pbl']/mods:displayForm" />
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="publisher_place">
+      <xsl:choose>
+        <xsl:when test="mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']">
+          <xsl:value-of select="mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
+        </xsl:when>
+        <xsl:when
+          test="mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']">
+          <xsl:value-of
+            select="mods:relatedItem[@type='host']/mods:originInfo[not(@eventType) or @eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="string-length($publisher_name) &gt; 0">
+      <xsl:choose>
+        <xsl:when test="string-length($publisher_place) &gt; 0">
+          <dc:source xsi:type="ddb:noScheme">
+            <xsl:value-of select="concat($publisher_place,' : ',$publisher_name)" />
+          </dc:source>
+        </xsl:when>
+        <xsl:otherwise>
+          <dc:source xsi:type="ddb:noScheme">
+            <xsl:value-of select="$publisher_name" />
+          </dc:source>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template mode="repositoryPublisher" match="mods:mods">
+    <xsl:choose>
+      <xsl:when
+        test="mods:originInfo[@eventType='publication']/mods:publisher and mods:originInfo[@eventType='publication']/mods:place/mods:placeTerm[@type='text']">
+        <xsl:call-template name="repositoryPublisherElement">
+          <xsl:with-param name="name" select="mods:originInfo[@eventType='publication']/mods:publisher" />
+          <xsl:with-param name="place" select="mods:originInfo[@eventType='publication']/mods:place/mods:placeTerm[@type='text']" />
+          <xsl:with-param name="address" select="''" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="mods:name[mods:role/mods:roleTerm/text()='his' and @valueURI]">
+        <xsl:variable name="insti" select="substring-after(mods:name[mods:role/mods:roleTerm/text()='his' and @valueURI]/@valueURI, '#')" />
+        <xsl:variable name="myURI" select="concat('classification:metadata:0:parents:mir_institutes:',$insti)" />
+        <xsl:variable name="cat" select="document($myURI)//category[@ID=$insti]/ancestor-or-self::category[label[lang('x-place')]][1]" />
+        <xsl:variable name="place" select="$cat/label[@xml:lang='x-place']/@text" />
+        <xsl:choose>
+          <xsl:when test="$place">
+            <xsl:variable name="placeSet" select="xalan:tokenize(string($place),'|')" />
+            <xsl:variable name="address">
+              <xsl:choose>
+                <xsl:when test="$placeSet[3]">
+                  <xsl:value-of select="$placeSet[3]" />
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="''" />
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:call-template name="repositoryPublisherElement">
+              <xsl:with-param name="name" select="$placeSet[1]" />
+              <xsl:with-param name="place" select="$placeSet[2]" />
+              <xsl:with-param name="address" select="$address" />
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="repositoryPublisherElement">
+              <xsl:with-param name="name" select="$MCR.OAIDataProvider.RepositoryPublisherName" />
+              <xsl:with-param name="place" select="$MCR.OAIDataProvider.RepositoryPublisherPlace" />
+              <xsl:with-param name="address" select="$MCR.OAIDataProvider.RepositoryPublisherAddress" />
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="repositoryPublisherElement">
+          <xsl:with-param name="name" select="$MCR.OAIDataProvider.RepositoryPublisherName" />
+          <xsl:with-param name="place" select="$MCR.OAIDataProvider.RepositoryPublisherPlace" />
+          <xsl:with-param name="address" select="$MCR.OAIDataProvider.RepositoryPublisherAddress" />
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="repositoryPublisherElement">
+    <xsl:param name="name" />
+    <xsl:param name="place" />
+    <xsl:param name="address" />
+    <dc:publisher xsi:type="cc:Publisher" type="dcterms:ISO3166" countryCode="DE">
+      <cc:universityOrInstitution>
+        <cc:name>
+          <xsl:value-of select="$name" />
+        </cc:name>
+        <cc:place>
+          <xsl:value-of select="$place" />
+        </cc:place>
+      </cc:universityOrInstitution>
+      <cc:address cc:Scheme="DIN5008">
+        <xsl:value-of select="$address" />
+      </cc:address>
+    </dc:publisher>
+  </xsl:template>
+
+  <xsl:template mode="contributor" match="mods:mods">
+    <xsl:variable name="contributorRoles" select="$marcrelator/mycoreclass/categories/category[@ID='ctb']/descendant-or-self::category" />
+    <xsl:for-each select="mods:name[$contributorRoles/@ID=mods:role/mods:roleTerm/text()]">
+      <dc:contributor xsi:type="pc:Contributor">
+        <xsl:apply-templates select="." mode="pc-person" />
+      </dc:contributor>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="date" match="mods:mods">
+    <xsl:if test="mods:originInfo[@eventType='creation']/mods:dateOther[@type='accepted'][@encoding='w3cdtf']">
+      <dcterms:dateAccepted xsi:type="dcterms:W3CDTF">
+        <xsl:value-of select="mods:originInfo[@eventType='creation']/mods:dateOther[@type='accepted'][@encoding='w3cdtf']" />
+      </dcterms:dateAccepted>
+    </xsl:if>
+    <xsl:if test="mods:originInfo[@eventType='publication']/mods:dateIssued[@encoding='w3cdtf']">
+      <dcterms:issued xsi:type="dcterms:W3CDTF">
+        <xsl:value-of select="mods:originInfo[@eventType='publication']/mods:dateIssued[@encoding='w3cdtf']" />
+      </dcterms:issued>
+    </xsl:if>
+    <xsl:for-each select="../../../../service/servdates/servdate[@type='modifydate']">
+      <dcterms:modified xsi:type="dcterms:W3CDTF">
+        <xsl:value-of select="." />
+      </dcterms:modified>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="type" match="mods:mods">
+    <dc:type xsi:type="dini:PublType">
+      <xsl:choose>
+        <xsl:when test="contains(mods:classification/@authorityURI,'diniPublType')">
+          <xsl:value-of select="substring-after(mods:classification[contains(@authorityURI,'diniPublType')]/@valueURI,'diniPublType#')" />
+        </xsl:when>
+        <xsl:when test="contains(mods:genre/@valueURI, 'article')">
+          <xsl:text>contributionToPeriodical</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(mods:genre/@valueURI, 'issue')">
+          <xsl:text>PeriodicalPart</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(mods:genre/@valueURI, 'journal')">
+          <xsl:text>Periodical</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(mods:genre/@valueURI, 'book')">
+          <xsl:text>book</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(mods:genre/@valueURI, 'dissertation') or
+                contains(mods:genre/@valueURI, 'habilitation')">
+          <xsl:text>doctoralThesis</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>Other</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </dc:type>
+    <dc:type xsi:type="dcterms:DCMIType">
+      <xsl:text>Text</xsl:text>
+    </dc:type>
+    <dini:version_driver>
+      <xsl:text>publishedVersion</xsl:text>
+    </dini:version_driver>
+  </xsl:template>
+
+  <xsl:template mode="identifier" match="mods:mods">
+    <xsl:for-each select="mods:identifier[@type='urn']">
+      <dc:identifier xsi:type="urn:nbn">
+        <xsl:value-of select="." />
+      </dc:identifier>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template mode="format" match="mods:mods">
+    <xsl:apply-templates select="$ifs/der/mcr_directory/children/child[generate-id(.)=generate-id(key('contentType', contentType)[1])]"
+      mode="format" />
+  </xsl:template>
+
+  <xsl:template mode="format" match="child">
+    <dcterms:medium xsi:type="dcterms:IMT">
+      <xsl:value-of select="contentType" />
+    </dcterms:medium>
+  </xsl:template>
+
+  <xsl:template mode="relatedItem2source" match="mods:mods">
+      <!--  If not use isPartOf use dc:source -->
+    <xsl:for-each select="mods:relatedItem[@type='host']">
+      <xsl:variable name="hosttitel" select="mods:titleInfo/mods:title" />
+      <xsl:variable name="issue" select="mods:part/mods:detail[@type='issue']/mods:number" />
+      <xsl:variable name="volume" select="mods:part/mods:detail[@type='volume']/mods:number" />
+      <xsl:variable name="startPage" select="mods:part/mods:extent[@unit='pages']/mods:start" />
+      <xsl:variable name="endPage" select="mods:part/mods:extent[@unit='pages']/mods:end" />
+      <xsl:variable name="volume2">
+        <xsl:if test="string-length($volume) &gt; 0">
+          <xsl:value-of select="concat('(',$volume,')')" />
+        </xsl:if>
+      </xsl:variable>
+      <xsl:variable name="issue2">
+        <xsl:if test="string-length($issue) &gt; 0">
+          <xsl:value-of select="concat(', H. ',$issue)" />
+        </xsl:if>
+      </xsl:variable>
+      <xsl:variable name="pages">
+        <xsl:if test="string-length($startPage) &gt; 0">
+          <xsl:value-of select="concat(', S.',$startPage,'-',$endPage)" />
+        </xsl:if>
+      </xsl:variable>
+      <dc:source xsi:type="ddb:noScheme">
+        <xsl:value-of select="concat($hosttitel,$volume2,$issue2,$pages)" />
+      </dc:source>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="language">
+    <dc:language xsi:type="dcterms:ISO639-2">
+      <xsl:value-of select="$language" />
+    </dc:language>
+  </xsl:template>
 
 <!-- dcterms:isPartOf xsi:type="ddb:Erstkat-ID" >2049984-X</dcterms:isPartOf>
 <dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe" >2004</dcterms:isPartOf -->
-    <xsl:template name="relatedItem2ispartof">
+  <xsl:template mode="relatedItem2ispartof" match="mods:mods">
       <!-- Ausgabe der Schriftenreihe ala: <dcterms:isPartOf xsi:type=“ddb:noScheme“>Bulletin ; 34</dcterms:isPartOf>  -->
-      <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem/@type='series'">
-        <xsl:element name="dcterms:isPartOf">
-          <xsl:attribute name="xsi:type">ddb:noScheme</xsl:attribute>
-          <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='series']/mods:titleInfo/mods:title" />
-          <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number">
-            <xsl:value-of select="concat(' ; ',./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number)"/>
-          </xsl:if>
-        </xsl:element>
-      </xsl:if>
-      <xsl:if test="contains(./metadata/def.modsContainer/modsContainer/mods:mods/mods:genre/@valueURI, 'issue')">
-        <xsl:element name="dcterms:isPartOf">
-          <xsl:attribute name="xsi:type">ddb:ZSTitelID</xsl:attribute>
-          <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/@xlink:href" />
-        </xsl:element>
-        <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']">
-          <xsl:element name="dcterms:isPartOf">
-            <xsl:attribute name="xsi:type">ddb:ZS-Ausgabe</xsl:attribute>
-            <xsl:choose>
-              <xsl:when test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']">
-                <xsl:value-of select="concat(normalize-space(./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']),
-                                            ', ',
-                                            i18n:translate('component.mods.metaData.dictionary.issue'),
-                                            ' ',
-                                            normalize-space(./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']))" />
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:value-of select="normalize-space(./metadata/def.modsContainer/modsContainer/mods:mods/mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume'])" />
-                </xsl:otherwise>
-              </xsl:choose>
-          </xsl:element>
+    <xsl:if test="mods:relatedItem/@type='series'">
+      <dcterms:isPartOf xsi:type="ddb:noScheme">
+        <xsl:value-of select="mods:relatedItem[@type='series']/mods:titleInfo/mods:title" />
+        <xsl:if test="mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number">
+          <xsl:value-of select="concat(' ; ',mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number)" />
         </xsl:if>
+      </dcterms:isPartOf>
+    </xsl:if>
+    <xsl:if test="contains(mods:genre/@valueURI, 'issue')">
+      <dcterms:isPartOf xsi:type="ddb:ZSTitelID">
+        <xsl:value-of select="mods:relatedItem[@type='host']/@xlink:href" />
+      </dcterms:isPartOf>
+      <xsl:if test="mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']">
+        <dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe">
+          <xsl:choose>
+            <xsl:when test="mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']">
+              <xsl:value-of
+                select="concat(normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']),
+                  ', ',
+                  i18n:translate('component.mods.metaData.dictionary.issue'),
+                  ' ',
+                  normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']))" />
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume'])" />
+            </xsl:otherwise>
+          </xsl:choose>
+        </dcterms:isPartOf>
       </xsl:if>
+    </xsl:if>
+  </xsl:template>
 
-    </xsl:template>
-
-    <xsl:template name="degree">
-        <xsl:variable name="thesis_level">
-            <xsl:for-each select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:classification">
-                <xsl:if test="contains(./@authorityURI,'XMetaDissPlusThesisLevel')">
-                    <xsl:element name="thesis:level">
-                        <xsl:value-of select="substring-after(./@valueURI,'#')"/>
-                    </xsl:element>
-                </xsl:if>
-            </xsl:for-each>
-        </xsl:variable>
-        <xsl:if test="string-length($thesis_level) &gt; 0">
-            <xsl:element name="thesis:degree">
-                <xsl:copy-of select="$thesis_level"/>
-                <xsl:if test="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='creation']/mods:publisher">
-                    <xsl:element name="thesis:grantor">
-                        <xsl:attribute name="xsi:type">cc:Corporate</xsl:attribute>
-                        <xsl:attribute name="type">dcterms:ISO3166</xsl:attribute>
-                        <xsl:attribute name="countryCode">DE</xsl:attribute>
-                        <xsl:element name="cc:universityOrInstitution">
-                           <xsl:element name="cc:name">
-                               <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='creation']/mods:publisher" />
-                           </xsl:element>
-                           <xsl:element name="cc:place">
-                               <xsl:value-of select="./metadata/def.modsContainer/modsContainer/mods:mods/mods:originInfo[@eventType='creation']/mods:place/mods:placeTerm" />
-                           </xsl:element>
-                       </xsl:element>
-                    </xsl:element>
-                </xsl:if>
-            </xsl:element>
+  <xsl:template mode="degree" match="mods:mods">
+    <xsl:variable name="thesis_level">
+      <xsl:for-each select="mods:classification">
+        <xsl:if test="contains(./@authorityURI,'XMetaDissPlusThesisLevel')">
+          <thesis:level>
+            <xsl:value-of select="substring-after(./@valueURI,'#')" />
+          </thesis:level>
         </xsl:if>
-    </xsl:template>
-
-    <xsl:template name="contact">
-        <xsl:element name="ddb:contact">
-            <xsl:attribute name="ddb:contactID">
-                <xsl:choose>
-                    <xsl:when test="./metadata/contacts/contact">
-                        <xsl:value-of select="./metadata/contacts/contact" />
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:text>F6001-3079</xsl:text>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:attribute>
-        </xsl:element>
-    </xsl:template>
-
-    <xsl:template name="fileproperties">
-      <xsl:param name="derId" select="''" />
-      <xsl:param name="filenumber" select="1" />
-
-      <xsl:variable name="details" select="document(concat('ifs:',$derId,'/'))" />
-      <xsl:for-each select="$details/mcr_directory/children/child[@type='file']">
-         <xsl:element name="ddb:fileProperties">
-             <xsl:attribute name="ddb:fileName"><xsl:value-of select="./name" /></xsl:attribute>
-             <xsl:attribute name="ddb:fileID"><xsl:value-of select="./uri" /></xsl:attribute>
-             <xsl:attribute name="ddb:fileSize"><xsl:value-of select="./size" /></xsl:attribute>
-             <xsl:if test="$filenumber &gt; 1">
-                <xsl:attribute name="ddb:fileDirectory"><xsl:value-of select="$details/mcr_directory/path" /></xsl:attribute><!-- TODO: check! -->
-             </xsl:if>
-         </xsl:element>
       </xsl:for-each>
-      <!-- xsl:for-each select="$details/mcr_directory/children/child[@type='directory']">
-        <xsl:call-template name="fileproperties">
-           <xsl:with-param name="detailsURL" select="$detailsURL" />
-           <xsl:with-param name="derpath" select="concat($details/mcr_directory/path,'/',name)" />
-           <xsl:with-param name="filenumber" select="$filenumber" />
-        </xsl:call-template>
-      </xsl:for-each -->
-    </xsl:template>
+    </xsl:variable>
+    <xsl:if test="string-length($thesis_level) &gt; 0">
+      <thesis:degree>
+        <xsl:copy-of select="$thesis_level" />
+        <xsl:if test="mods:originInfo[@eventType='creation']/mods:publisher">
+          <thesis:grantor xsi:type="cc:Corporate" type="dcterms:ISO3166" countryCode="DE">
+            <cc:universityOrInstitution>
+              <cc:name>
+                <xsl:value-of select="mods:originInfo[@eventType='creation']/mods:publisher" />
+              </cc:name>
+              <cc:place>
+                <xsl:value-of select="mods:originInfo[@eventType='creation']/mods:place/mods:placeTerm" />
+              </cc:place>
+            </cc:universityOrInstitution>
+          </thesis:grantor>
+        </xsl:if>
+      </thesis:degree>
+    </xsl:if>
+  </xsl:template>
 
-    <xsl:template name="file">
-        <xsl:for-each select="./structure/derobjects/derobject[1]">
-            <xsl:variable name="derId" select="@xlink:href" />
-            <xsl:variable name="ifsDirectory" select="document(concat('ifs:',$derId,'/'))" />
-            <xsl:variable name="isRelevantDerivate">
-              <xsl:for-each select="$ifsDirectory/mcr_directory/children/child[@type='file']">
-                <xsl:if test="contains(./contentType,'pdf') or
-                              contains(./contentType,'ps')  or
-                              contains(./contentType,'audio/mpeg') or
-                              contains(./contentType,'audio/x-wav') or
-                              contains(./contentType,'zip')">
-                  <xsl:value-of select="'true'" />
-                </xsl:if>
-              </xsl:for-each>
-            </xsl:variable>
-            <xsl:if test="contains($isRelevantDerivate,'true')">
-              <xsl:variable name="ddbfilenumber" select="$ifsDirectory/mcr_directory/numChildren/here/files" />
-              <xsl:element name="ddb:fileNumber">
-                  <xsl:value-of select="$ddbfilenumber" />
-              </xsl:element>
-               <xsl:call-template name="fileproperties">
-                  <xsl:with-param name="derId" select="./@xlink:href" />
-                  <xsl:with-param name="filenumber" select="number($ddbfilenumber)" />
-               </xsl:call-template>
-               <xsl:if test="number($ddbfilenumber) &gt; 0">
-                  <xsl:element name="ddb:transfer">
-                     <xsl:attribute name="ddb:type">dcterms:URI</xsl:attribute>
-                     <xsl:value-of select="concat($ServletsBaseURL,'MCRZipServlet/',./@xlink:href)" />
-                  </xsl:element>
-               </xsl:if>
-            </xsl:if>
-        </xsl:for-each>
-    </xsl:template>
+  <xsl:template name="file">
+    <xsl:if test="$ifs/der">
+      <xsl:variable name="ddbfilenumber" select="count($ifs/der/mcr_directory/children//child[@type='file'])" />
+      <ddb:fileNumber>
+        <xsl:value-of select="$ddbfilenumber" />
+      </ddb:fileNumber>
+      <xsl:apply-templates mode="fileproperties" select="$ifs/der">
+        <xsl:with-param name="totalFiles" select="$ddbfilenumber" />
+      </xsl:apply-templates>
+      <ddb:transfer ddb:type="dcterms:URI">
+        <xsl:choose>
+          <xsl:when test="$ddbfilenumber = 1">
+            <xsl:variable name="uri" select="$ifs/der/mcr_directory/children//child[@type='file']/uri" />
+            <xsl:variable name="derId" select="substring-before(substring-after($uri,':/'), ':')" />
+            <xsl:variable name="filePath" select="substring-after(substring-after($uri, ':'), ':')" />
+            <xsl:value-of select="concat($ServletsBaseURL,'MCRFileNodeServlet/',$derId,$filePath)" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat($ServletsBaseURL,'MCRZipServlet/',/mycoreobject/@ID)" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </ddb:transfer>
+    </xsl:if>
+  </xsl:template>
 
-    <xsl:template name="frontpage">
-        <xsl:element name="ddb:identifier">
-            <xsl:attribute name="ddb:type">URL</xsl:attribute>
-            <xsl:value-of select="concat($WebApplicationBaseURL,'receive/',/mycoreobject/@ID)"/>
-        </xsl:element>
-    </xsl:template>
+  <xsl:template mode="fileproperties" match="der[@id]">
+    <xsl:param name="totalFiles" />
+    <xsl:variable name="derId" select="@id" />
+    <xsl:for-each select="mcr_directory/children//child[@type='file']">
+      <ddb:fileProperties>
+        <xsl:attribute name="ddb:fileName"><xsl:value-of select="name" /></xsl:attribute>
+        <xsl:attribute name="ddb:fileID"><xsl:value-of select="uri" /></xsl:attribute>
+        <xsl:attribute name="ddb:fileSize"><xsl:value-of select="size" /></xsl:attribute>
+        <xsl:if test="$totalFiles &gt; 1">
+          <xsl:attribute name="ddb:fileDirectory">
+            <xsl:value-of select="concat($derId, substring-after(uri, concat('ifs:/',$derId,':')))" />
+          </xsl:attribute>
+        </xsl:if>
+      </ddb:fileProperties>
+    </xsl:for-each>
+  </xsl:template>
 
-    <xsl:template name="rights">
+  <xsl:template mode="frontpage" match="mycoreobject">
+    <ddb:identifier ddb:type="URL">
+      <xsl:value-of select="concat($WebApplicationBaseURL,'receive/',@ID)" />
+    </ddb:identifier>
+  </xsl:template>
+
+  <xsl:template name="rights">
       <!-- TODO: check access permission -->
       <!-- xsl:element name="ddb:rights">
        <xsl:attribute name="ddb:kind">free</xsl:attribute>
       </xsl:element -->
-      <ddb:rights ddb:kind="free" />
-    </xsl:template>
+    <ddb:rights ddb:kind="free" />
+  </xsl:template>
 
 </xsl:stylesheet>

--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -269,12 +269,8 @@
             </pc:organisationName>
           </xsl:when>
           <xsl:when test="mods:namePart[@type='family'] and mods:namePart[@type='given']">
-            <pc:foreName>
-              <xsl:value-of select="normalize-space(mods:namePart[@type='given'])" />
-            </pc:foreName>
-            <pc:surName>
-              <xsl:value-of select="normalize-space(mods:namePart[@type='family'])" />
-            </pc:surName>
+            <xsl:apply-templates select="mods:namePart[@type='given']" mode="pc-person" />
+            <xsl:apply-templates select="mods:namePart[@type='family']" mode="pc-person" />
           </xsl:when>
           <xsl:when test="contains(mods:displayForm, ',')">
             <pc:foreName>
@@ -292,6 +288,18 @@
         </xsl:choose>
       </pc:name>
     </pc:person>
+  </xsl:template>
+  
+  <xsl:template mode="pc-person" match="mods:namePart[@type='family']">
+    <pc:surName>
+      <xsl:value-of select="normalize-space(.)" />
+    </pc:surName>
+  </xsl:template>
+
+  <xsl:template mode="pc-person" match="mods:namePart[@type='given']">
+    <pc:foreName>
+      <xsl:value-of select="." />
+    </pc:foreName>
   </xsl:template>
 
   <xsl:template mode="subject" match="mods:mods">

--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -268,6 +268,14 @@
               <xsl:value-of select="mods:displayForm" />
             </pc:organisationName>
           </xsl:when>
+          <xsl:when test="mods:namePart[@type='family'] and mods:namePart[@type='given']">
+            <pc:foreName>
+              <xsl:value-of select="normalize-space(mods:namePart[@type='given'])" />
+            </pc:foreName>
+            <pc:surName>
+              <xsl:value-of select="normalize-space(mods:namePart[@type='family'])" />
+            </pc:surName>
+          </xsl:when>
           <xsl:when test="contains(mods:displayForm, ',')">
             <pc:foreName>
               <xsl:value-of select="normalize-space(substring-after(mods:displayForm,','))" />

--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -616,6 +616,7 @@
   <xsl:template name="file">
     <xsl:if test="$ifs/der">
       <xsl:variable name="ddbfilenumber" select="count($ifs/der/mcr_directory/children//child[@type='file'])" />
+      <xsl:variable name="dernumber" select="count($ifs/der)" />
       <ddb:fileNumber>
         <xsl:value-of select="$ddbfilenumber" />
       </ddb:fileNumber>
@@ -631,7 +632,14 @@
             <xsl:value-of select="concat($ServletsBaseURL,'MCRFileNodeServlet/',$derId,$filePath)" />
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="concat($ServletsBaseURL,'MCRZipServlet/',/mycoreobject/@ID)" />
+            <xsl:choose>
+              <xsl:when test="$dernumber = 1">
+                <xsl:value-of select="concat($ServletsBaseURL,'MCRZipServlet/',$ifs/der/@id)" />
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="concat($ServletsBaseURL,'MCRZipServlet/',/mycoreobject/@ID)" />
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:otherwise>
         </xsl:choose>
       </ddb:transfer>


### PR DESCRIPTION
The stylesheet could be optimized:

    Always trust the metadata
        Do not query external systems like GND
        Do not query mycore-pi
    Do not traverse the tree if not needed and use XSL contexts
    Support multiple derivates per document
        Resolve derivates only once
        Do not use hidden derivates
        Resolve all directories and files and not only to top directory
        Use Muenchian Method to get content types
    Language classification is loaded once and use xsl:key to search for categories
    Use marcrelator classification to get creator and contributor roles