### PR TITLE
MIR-676 fixed dc:rights

### DIFF
--- a/mir-module/src/main/resources/xsl/mods2oai_dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2oai_dc.xsl
@@ -83,6 +83,9 @@
             <xsl:apply-templates select="mods:language" />
             <xsl:apply-templates select="mods:relatedItem" />
             <xsl:apply-templates select="mods:accessCondition" />
+            <xsl:apply-templates select="." mode="eu-repo-accessRights">
+              <xsl:with-param name="objId" select="$objId" />
+            </xsl:apply-templates>
 
     </oai_dc:dc>
   </xsl:for-each>


### PR DESCRIPTION
choose of 'info:eu-repo/semantics/*' is exclusive
dc:rights from classification works with every classification
dc:rights content should be english if english labels are present