### PR TITLE
MIR-788 shariff is now compatible with our fontawesome version

### DIFF
--- a/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
@@ -11,7 +11,7 @@
       <xsl:copy-of select="@*" />
       <head>
         <xsl:apply-templates select="citation_meta" mode="copyContent" />
-        <link href="{$WebApplicationBaseURL}mir-layout/assets/jquery/plugins/shariff/shariff.complete.css" rel="stylesheet" />
+        <link href="{$WebApplicationBaseURL}mir-layout/assets/jquery/plugins/shariff/shariff.min.css" rel="stylesheet" />
       </head>
 
       <xsl:if test="div[@id='mir-breadcrumb']">


### PR DESCRIPTION
we can use shariff.min.css

[Link to jira](https://mycore.atlassian.net/browse/MIR-788).
