### PR TITLE
MIR-842 copy current issue url fix layout issues caused by bootsrap 4 migration

### DIFF
--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/forms.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/forms.scss
@@ -17,10 +17,6 @@
   top: 0;
 }
 
-*:not(.input-group-btn)/*:not(.btn-group)*/ > .btn {
-  margin-right: 5px;
-}
-
 .form-pmud .btn {
 //deprecated
   margin-right: 2px;

--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/forms.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/forms.scss
@@ -187,7 +187,7 @@ span.topicExtended-container input.topic_gnd, span.geographicExtended-container 
 /* mir relatedItemsearch                           */
 /***************************************************/
 .mir-relatedItem-body{
-  margin-top:15px;
+  padding-top:15px;
   border-style: solid;
   border-width: 0px 0px 0px 2px;
   border-color: #ccc;
@@ -195,7 +195,7 @@ span.topicExtended-container input.topic_gnd, span.geographicExtended-container 
 }
 
 .mir-relatedItem-head{
-  margin-bottom: 15px;
+  margin-bottom: 0;
   border-style: solid;
   border-width: 2px 2px 2px 2px;
   border-color: #ccc;

--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_metadata.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_metadata.scss
@@ -141,7 +141,7 @@ $grayDark: #ECF0F1 !default;
     span {
       cursor: pointer;
     }
-    span.fa {
+    span.fas {
       color: #ccc;
       margin-right: 0.5em;
     }

--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/user-login.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/user-login.scss
@@ -2,3 +2,6 @@
 .form-login .form-control {
   width: 30%;
 }
+.form-login .form-actions .btn:first-child {
+  margin-right: 0.5rem;
+}

--- a/mir-module/src/main/resources/xsl/layout/mir-navigation.xsl
+++ b/mir-module/src/main/resources/xsl/layout/mir-navigation.xsl
@@ -30,7 +30,7 @@
       </li>
     </xsl:if>
     <xsl:apply-templates />
-    <li role="presentation" class="divider" />
+    <li role="presentation" class="dropdown-divider" />
   </xsl:template>
 
   <xsl:template match="/navigation//item[@href]">

--- a/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
@@ -239,10 +239,10 @@
                     </xsl:choose>
                   </xsl:variable>
                   <li class="float-right nav-item">
-                    <xsl:if test="position()=1">
-                      <xsl:attribute name="class">active float-right nav-item</xsl:attribute>
-                    </xsl:if>
                     <a class="nav-link" href="#tab{position()}" role="tab" data-toggle="tab">
+                      <xsl:if test="position()=1">
+                        <xsl:attribute name="class">active nav-link</xsl:attribute>
+                      </xsl:if>
                       <xsl:value-of select="$tabName" />
                     </a>
                   </li>

--- a/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
@@ -238,11 +238,11 @@
                       </xsl:otherwise>
                     </xsl:choose>
                   </xsl:variable>
-                  <li class="float-right">
+                  <li class="float-right nav-item">
                     <xsl:if test="position()=1">
-                      <xsl:attribute name="class">active float-right</xsl:attribute>
+                      <xsl:attribute name="class">active float-right nav-item</xsl:attribute>
                     </xsl:if>
-                    <a href="#tab{position()}" role="tab" data-toggle="tab">
+                    <a class="nav-link" href="#tab{position()}" role="tab" data-toggle="tab">
                       <xsl:value-of select="$tabName" />
                     </a>
                   </li>

--- a/mir-module/src/main/resources/xsl/metadata/mir-citation.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-citation.xsl
@@ -262,15 +262,24 @@
   </xsl:template>
 
   <xsl:template match="mods:mods" mode="identifierListModal">
-    <div id="identifierModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal frame" aria-hidden="true">
+    <div
+      id="identifierModal"
+      class="modal fade"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="modal frame"
+      aria-hidden="true">
       <div class="modal-dialog modal-lg modal-xl" role="document">
         <div class="modal-content">
-
           <div class="modal-header">
             <h4 class="modal-title" id="modalFrame-title">
               <xsl:value-of select="i18n:translate('mir.citationLink')" />
             </h4>
-            <button type="button" class="close modalFrame-cancel" data-dismiss="modal" aria-label="Close">
+            <button
+              type="button"
+              class="close modalFrame-cancel"
+              data-dismiss="modal"
+              aria-label="Close">
               <i class="fas fa-times" aria-hidden="true"></i>
             </button>
           </div>
@@ -283,7 +292,6 @@
               </xsl:call-template>
             </xsl:if>
           </div>
-
         </div>
       </div>
     </div>

--- a/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
@@ -182,22 +182,38 @@
                 <xsl:apply-templates select="div[@id='mir-admindata']" mode="newMetadata" />
                 <!-- End: ADMINMETADATA -->
               </div>
-              <div class="modal fade" id="historyModal" tabindex="-1" role="dialog" aria-labelledby="modal frame" aria-hidden="true">
-                <div class="modal-dialog" style="width: 930px">
+              <div
+                  id="historyModal"
+                  class="modal fade"
+                  tabindex="-1"
+                  role="dialog"
+                  aria-labelledby="modal frame"
+                  aria-hidden="true">
+                <div
+                  class="modal-dialog modal-lg modal-xl"
+                  role="document">
                   <div class="modal-content">
                     <div class="modal-header">
-                      <button type="button" class="close modalFrame-cancel" data-dismiss="modal" aria-label="Close">
-                        <i class="fas fa-times" aria-hidden="true"></i>
-                      </button>
                       <h4 class="modal-title" id="modalFrame-title">
                         <xsl:value-of select="i18n:translate('metadata.versionInfo.label')" />
                       </h4>
+                      <button
+                        type="button"
+                        class="close modalFrame-cancel"
+                        data-dismiss="modal"
+                        aria-label="Close">
+                        <i class="fas fa-times" aria-hidden="true"></i>
+                      </button>
                     </div>
-                    <div id="modalFrame-body" class="modal-body" style="max-height: 560px; overflow: auto">
+                    <div id="modalFrame-body" class="modal-body">
                       <xsl:apply-templates select="div[@id='mir-historydata']" mode="copyContent" />
                     </div>
-                    <div class="modal-footer" style="clear: both">
-                      <button id="modalFrame-cancel" type="button" class="btn btn-danger" data-dismiss="modal">
+                    <div class="modal-footer">
+                      <button
+                        id="modalFrame-cancel"
+                        type="button"
+                        class="btn btn-danger"
+                        data-dismiss="modal">
                         <xsl:value-of select="i18n:translate('button.cancel')" />
                       </button>
                     </div>

--- a/mir-module/src/main/resources/xsl/xeditor-mir-templates.xsl
+++ b/mir-module/src/main/resources/xsl/xeditor-mir-templates.xsl
@@ -73,14 +73,14 @@
     <xsl:if test="string-length(@i18n) &gt; 0">
       <xsl:apply-templates select="." mode="label" />
     </xsl:if>
+    <xsl:comment>
+      TODO:
+      The property MIR.Layout.inputSize ($input-size) can be set to the old
+      bs3 responsive level 'xs', but in bs4 'xs' is not used anymore in class
+      names. So a simple concat will cause errors. Check the mir code if
+      this property forces a condition check elsewhere too.
+    </xsl:comment>
     <div>
-      <xsl:comment>
-        TODO:
-        The property MIR.Layout.inputSize ($input-size) can be set to the old
-        bs3 responsive level 'xs', but in bs4 'xs' is not used anymore in class
-        names. So a simple concat will cause errors. Check the mir code if
-        this property forces a condition check elsewhere too.
-      </xsl:comment>
       <xsl:attribute name="class">
         <xsl:choose>
           <xsl:when test="contains($input-size, 'xs')">
@@ -149,10 +149,16 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-
     <div>
       <xsl:attribute name="class">
-        <xsl:value-of select="concat('col-', $colsize, '-', $colwidth, ' ')" />
+        <xsl:choose>
+          <xsl:when test="contains($colsize, 'xs')">
+            <xsl:value-of select="concat('col-', $colwidth, ' ')" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat('col-', $colsize, '-', $colwidth, ' ')" />
+          </xsl:otherwise>
+        </xsl:choose>
         <xsl:value-of select="'{$xed-validation-marker}'" />
       </xsl:attribute>
       <xsl:choose>


### PR DESCRIPTION
Fixes minor layout issues, caused by bootstrap 4:
- removed global margin right from buttons, caused by an outdated css class and custom rule
- fixes side effect by adding space to login buttons
- repairs the modal dialogue for document version history e.g.
