### PR TITLE
MIR-852 Adds IE11 fix for sticky footer

### DIFF
--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/base.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/base.scss
@@ -37,16 +37,19 @@ header {
 
 // align the footer to the bottom
 body {
-    display: flex; // use flex box model
-    flex-direction: column; // sort items in a column
-    min-height: 100vh; // use full view port height
+  display: flex;          // use flex box model
+  flex-direction: column; // sort items in a column
+  height: 100vh;          // use full view port height
 }
-section {
-    flex: 1; // will use all available space left
+body > section {
+  flex: 1 0 auto; // will use all available space left
+                  // long notation is needed for IE11
+}
+body > header,
+body > footer {
+  flex-shrink: 0; // bypass the fix height from body
 }
 // end: align footer
-
-// end footer alignment
 
 // TODO move this to the typo styles
 p {

--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/base.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/base.scss
@@ -40,14 +40,15 @@ body {
   display: flex;          // use flex box model
   flex-direction: column; // sort items in a column
   height: 100vh;          // use full view port height
+                          // min-height is not working in IE11
 }
 body > section {
-  flex: 1 0 auto; // will use all available space left
+  flex: 1 0 auto; // flex: 1, will use all available space
                   // long notation is needed for IE11
 }
 body > header,
 body > footer {
-  flex-shrink: 0; // bypass the fix height from body
+  flex-shrink: 0; // define this explicit for IE11
 }
 // end: align footer
 


### PR DESCRIPTION
Added a IE11 fix for the sticky footer.

IE11 has other defaults for flexbox items.
Furthermore, IE11 did not know min-height.

Solution:
- used the long notation for the flex box item to prevent wrong defaults
- changed the min-height to height because IE11 do not support min-height
- set explicit the shrink behaviour of header and footer

[Link to jira](https://mycore.atlassian.net/browse/MIR-852).
