### PR TITLE
MIR-841 adjust handling multiple ids in admineditor

### DIFF
--- a/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
@@ -565,12 +565,16 @@
     
     var currentIdFieldIndex = 0;
     var nameIdFields = null;
+    var nameIdTypes = null;
+    
+    var nameIdTypesElements = null;
     
     var isNewNameFormGroup = true;
     
     if (item) {
       this.$element != $output && item.label && this.$element.val(item.label.replace(SearchEntity.LABEL_CLEANUP, ""));
- 
+      var outputType = getTypeFromURL(item.value);
+      
       if (item.type) {
 
         $outputNameType.val(item.type.toLowerCase());
@@ -586,30 +590,48 @@
           currentIdFieldIndex++;
         }
 
+        /*
+         * Get assigned name identifier types for the dependent
+         * personExtended_box
+         */
+        nameIdTypesElements = $(itemPersonExtendedBox).find('select[name*="/mods:nameIdentifier"]');
+
+        nameIdTypes = nameIdTypesElements.map(function () {return this.value;}).get();
+        
+        /*
+         * Output will replace an old value with same identifier type or will be
+         * the next free input field!
+         */
+        if (nameIdTypes.includes(outputType.toLowerCase())) {
+          var outputWithIdType =  $(nameIdTypesElements[0][nameIdTypes.indexOf(outputType.toLowerCase())]).closest('div.form-group').find('input[name*="/mods:nameIdentifier"]');
+          
+          if (outputWithIdType.val()) {
+            $output[0] = outputWithIdType[0];
+          }
+        } else {
         /* $output will be the next free Input field */
         $output[0] = nameIdFields[currentIdFieldIndex];
-
+        
         /* get dependent outputType selection */
         let dependentOutputType = $('select[name="' + nameIdFields[currentIdFieldIndex].name + '/@type"]');
         $outputType[0] = dependentOutputType[0];
+        }
 
         /* if there is not a free identifier output field anymore trigger button */
         nameIdFields.forEach((currentNameIdField, index) => {
           
-          if ((currentIdFieldIndex !== index) && (currentNameIdField.value === "")) {
+          if ((currentIdFieldIndex !== index) && (!currentNameIdField.value)) {
             isNewNameFormGroup = false;
           }
         });
-      }
-
+        }
+      
       $output.val(getIDFromURL(item.value));
-      var outputType = getTypeFromURL(item.value);
       if (outputType != "") {
         $outputType.val(outputType.toLowerCase());
       }
     }
     
-
     if ($output != this.$element && $output.val().length > 0) {
       var type = $outputType.val();
       var $feedback = $(document.createElement("a"));

--- a/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
@@ -570,18 +570,18 @@
     var nameIdTypesElements = null;
     
     var isNewNameFormGroup = true;
-    
+
     if (item) {
       this.$element != $output && item.label && this.$element.val(item.label.replace(SearchEntity.LABEL_CLEANUP, ""));
       var outputType = getTypeFromURL(item.value);
       
       if (item.type) {
-
+        
         $outputNameType.val(item.type.toLowerCase());
-
+        
         /* Get dependent personExtended_box */
         var itemPersonExtendedBox = $($output).closest('fieldset[class="personExtended_box"]');
-
+        
         /* get the next free output field */
         nameIdFields = $(itemPersonExtendedBox).find('input[name*="/mods:nameIdentifier"]');
         nameIdFields = nameIdFields.toArray();
@@ -589,13 +589,13 @@
         while (currentIdFieldIndex < nameIdFields.length && nameIdFields[currentIdFieldIndex].value) {
           currentIdFieldIndex++;
         }
-
+        
         /*
          * Get assigned name identifier types for the dependent
          * personExtended_box
          */
         nameIdTypesElements = $(itemPersonExtendedBox).find('select[name*="/mods:nameIdentifier"]');
-
+        
         nameIdTypes = nameIdTypesElements.map(function () {return this.value;}).get();
         
         /*
@@ -603,41 +603,43 @@
          * the next free input field!
          */
         if (nameIdTypes.includes(outputType.toLowerCase())) {
-         
+          
           /* note multiple id types on outputType */
-          let isPointerNotSetted = true;
-          let lastIndexWithIdType = null;
-
-          for (var ind=0; ind < nameIdTypes.length && isPointerNotSetted; ind++) {
-
-              if (nameIdTypes[ind] === outputType.toLowerCase()) {
-
-                  var outputWithIdType = $(nameIdTypesElements[ind]).closest('div.form-group').find('input[name*="/mods:nameIdentifier"]');
-
-                  if (outputWithIdType.val()) {
-                      $output[0] = outputWithIdType[0];
-                      $outputType[0] = nameIdTypesElements[ind];
-                      isPointerNotSetted = false;
-                  }
-                  
-                  lastIndexWithIdType = ind;
+          let depIndexWithIdType = null;
+          let defaultIndexWithIdType = null;
+          
+          for (var ind=0; ind < nameIdTypes.length && depIndexWithIdType === null; ind++) {
+            
+            if (nameIdTypes[ind] === outputType.toLowerCase()) {
+              
+              var outputWithIdType = $(nameIdTypesElements[ind]).closest('div.form-group').find('input[name*="/mods:nameIdentifier"]');
+              
+              if (outputWithIdType.val()) {
+                depIndexWithIdType = ind;
               }
+              
+              defaultIndexWithIdType = ind;
+            }
           }
           
-          /* avoid default pointer for $output and $outputType -> do not remove first */
-          if (isPointerNotSetted && lastIndexWithIdType != null) {
-            $output[0] = outputWithIdType[0];
-            $outputType[0] = nameIdTypesElements[lastIndexWithIdType];
-            isPointerNotSetted = false;
+          /*
+           * avoid default pointer for $output and $outputType -> do not remove
+           * first
+           */
+          if (depIndexWithIdType === null) {
+            depIndexWithIdType = defaultIndexWithIdType;
           }
+          
+          $output[0] = outputWithIdType[0];
+          $outputType[0] = nameIdTypesElements[depIndexWithIdType];
           
         } else {
-        /* $output will be the next free Input field */
-        $output[0] = nameIdFields[currentIdFieldIndex];
-        
-        /* get dependent outputType selection */
-        let dependentOutputType = $('select[name="' + nameIdFields[currentIdFieldIndex].name + '/@type"]');
-        $outputType[0] = dependentOutputType[0];
+          /* $output will be the next free Input field */
+          $output[0] = nameIdFields[currentIdFieldIndex];
+          
+          /* get dependent outputType selection */
+          let dependentOutputType = $('select[name="' + nameIdFields[currentIdFieldIndex].name + '/@type"]');
+          $outputType[0] = dependentOutputType[0];
         }
       }
       
@@ -654,7 +656,6 @@
         }
       });
     }
-    
     if ($output != this.$element && $output.val().length > 0) {
       var type = $outputType.val();
       var $feedback = $(document.createElement("a"));

--- a/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/jquery.search-entity.js
@@ -564,7 +564,7 @@
     var $outputNameType = $(options.searchOutputNameType, getParent(this.$element))[0] !== undefined ? $(options.searchOutputNameType, getParent(this.$element)).first() : this.$element;
     
     var currentIdFieldIndex = 0;
-    var nameIdFields = null;
+    var nameIdFields = [];
     var nameIdTypes = null;
     
     var nameIdTypesElements = null;
@@ -603,11 +603,34 @@
          * the next free input field!
          */
         if (nameIdTypes.includes(outputType.toLowerCase())) {
-          var outputWithIdType =  $(nameIdTypesElements[0][nameIdTypes.indexOf(outputType.toLowerCase())]).closest('div.form-group').find('input[name*="/mods:nameIdentifier"]');
-          
-          if (outputWithIdType.val()) {
-            $output[0] = outputWithIdType[0];
+         
+          /* note multiple id types on outputType */
+          let isPointerNotSetted = true;
+          let lastIndexWithIdType = null;
+
+          for (var ind=0; ind < nameIdTypes.length && isPointerNotSetted; ind++) {
+
+              if (nameIdTypes[ind] === outputType.toLowerCase()) {
+
+                  var outputWithIdType = $(nameIdTypesElements[ind]).closest('div.form-group').find('input[name*="/mods:nameIdentifier"]');
+
+                  if (outputWithIdType.val()) {
+                      $output[0] = outputWithIdType[0];
+                      $outputType[0] = nameIdTypesElements[ind];
+                      isPointerNotSetted = false;
+                  }
+                  
+                  lastIndexWithIdType = ind;
+              }
           }
+          
+          /* avoid default pointer for $output and $outputType -> do not remove first */
+          if (isPointerNotSetted && lastIndexWithIdType != null) {
+            $output[0] = outputWithIdType[0];
+            $outputType[0] = nameIdTypesElements[lastIndexWithIdType];
+            isPointerNotSetted = false;
+          }
+          
         } else {
         /* $output will be the next free Input field */
         $output[0] = nameIdFields[currentIdFieldIndex];
@@ -616,20 +639,20 @@
         let dependentOutputType = $('select[name="' + nameIdFields[currentIdFieldIndex].name + '/@type"]');
         $outputType[0] = dependentOutputType[0];
         }
-
-        /* if there is not a free identifier output field anymore trigger button */
-        nameIdFields.forEach((currentNameIdField, index) => {
-          
-          if ((currentIdFieldIndex !== index) && (!currentNameIdField.value)) {
-            isNewNameFormGroup = false;
-          }
-        });
-        }
+      }
       
       $output.val(getIDFromURL(item.value));
       if (outputType != "") {
         $outputType.val(outputType.toLowerCase());
       }
+      
+      /* if there is not a free identifier output field anymore trigger button */
+      nameIdFields.forEach((currentNameIdField, index) => {
+        
+        if (!currentNameIdField.value) {
+          isNewNameFormGroup = false;
+        }
+      });
     }
     
     if ($output != this.$element && $output.val().length > 0) {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-841).

agreed correction:
-> Support actively one ifentifer for one authority file organisation

The UI should only support a new nameidentifier input field creation if the maintained authority file organisation has not been selected already.
