### PR TITLE
MIR-883 update git-commit-id-plugin

### DIFF
--- a/mir-module/pom.xml
+++ b/mir-module/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>4.0.0</version>
         <configuration>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/org/mycore/mir/git.properties</generateGitPropertiesFilename>


### PR DESCRIPTION
removes dirty flag from bamboo builds

[Link to jira](https://mycore.atlassian.net/browse/MIR-883).
