### PR TITLE
MIR-934 make allowed roles for search in non published documents

### DIFF
--- a/mir-layout/src/main/resources/xsl/mir-cosmol-layout-utils.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-cosmol-layout-utils.xsl
@@ -4,11 +4,9 @@
     xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
     xmlns:mcrver="xalan://org.mycore.common.MCRCoreVersion"
     xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
-    xmlns:str="http://exslt.org/strings"
-    exclude-result-prefixes="i18n mcrver mcrxsl str">
+    exclude-result-prefixes="i18n mcrver mcrxsl">
 
   <xsl:import href="resource:xsl/layout/mir-common-layout.xsl" />
-  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:template  name="mir.header">
     <div id="header_box" class="clearfix container">
@@ -34,14 +32,6 @@
   <xsl:template name="mir.navigation">
     <div class="navbar navbar-default mir-side-nav searchfield_box">
       <nav class="mir-main-nav-entries">
-        
-        <xsl:variable name="isSearchAllowedForCurrentUser">
-          <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
-            <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
-              <xsl:text>true</xsl:text>
-            </xsl:if>
-          </xsl:for-each>
-        </xsl:variable>
         
         <form
           action="{$WebApplicationBaseURL}servlets/solr/find"

--- a/mir-layout/src/main/resources/xsl/mir-cosmol-layout-utils.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-cosmol-layout-utils.xsl
@@ -4,9 +4,11 @@
     xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
     xmlns:mcrver="xalan://org.mycore.common.MCRCoreVersion"
     xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
-    exclude-result-prefixes="i18n mcrver mcrxsl">
+    xmlns:str="http://exslt.org/strings"
+    exclude-result-prefixes="i18n mcrver mcrxsl str">
 
   <xsl:import href="resource:xsl/layout/mir-common-layout.xsl" />
+  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:template  name="mir.header">
     <div id="header_box" class="clearfix container">
@@ -32,6 +34,15 @@
   <xsl:template name="mir.navigation">
     <div class="navbar navbar-default mir-side-nav searchfield_box">
       <nav class="mir-main-nav-entries">
+        
+        <xsl:variable name="isSearchAllowedForCurrentUser">
+          <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
+            <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
+              <xsl:text>true</xsl:text>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        
         <form
           action="{$WebApplicationBaseURL}servlets/solr/find"
           class="searchfield_box form-inline my-2 my-lg-0"
@@ -46,7 +57,7 @@
               aria-label="Search"
               aria-describedby="" />
             <xsl:choose>
-              <xsl:when test="mcrxsl:isCurrentUserInRole('admin') or mcrxsl:isCurrentUserInRole('editor')">
+              <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
                 <input name="owner" type="hidden" value="createdby:*" />
               </xsl:when>
               <xsl:when test="not(mcrxsl:isCurrentUserGuestUser())">

--- a/mir-layout/src/main/resources/xsl/mir-flatmir-layout-utils.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-flatmir-layout-utils.xsl
@@ -4,11 +4,9 @@
     xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
     xmlns:mcrver="xalan://org.mycore.common.MCRCoreVersion"
     xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
-    xmlns:str="http://exslt.org/strings"
-    exclude-result-prefixes="i18n mcrver mcrxsl str">
+    exclude-result-prefixes="i18n mcrver mcrxsl">
 
   <xsl:import href="resource:xsl/layout/mir-common-layout.xsl" />
-  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:template name="mir.navigation">
 
@@ -63,14 +61,6 @@
               </xsl:for-each>
               <xsl:call-template name="mir.basketMenu" />
             </ul>
-
-            <xsl:variable name="isSearchAllowedForCurrentUser">
-              <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
-                <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
-                  <xsl:text>true</xsl:text>
-                </xsl:if>
-              </xsl:for-each>
-            </xsl:variable>
 
             <form
               action="{$WebApplicationBaseURL}servlets/solr/find"

--- a/mir-layout/src/main/resources/xsl/mir-flatmir-layout-utils.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-flatmir-layout-utils.xsl
@@ -4,9 +4,12 @@
     xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
     xmlns:mcrver="xalan://org.mycore.common.MCRCoreVersion"
     xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
-    exclude-result-prefixes="i18n mcrver mcrxsl">
+    xmlns:str="http://exslt.org/strings"
+    exclude-result-prefixes="i18n mcrver mcrxsl str">
 
   <xsl:import href="resource:xsl/layout/mir-common-layout.xsl" />
+  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
+
   <xsl:template name="mir.navigation">
 
     <div id="header_box" class="clearfix container">
@@ -61,6 +64,14 @@
               <xsl:call-template name="mir.basketMenu" />
             </ul>
 
+            <xsl:variable name="isSearchAllowedForCurrentUser">
+              <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
+                <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
+                  <xsl:text>true</xsl:text>
+                </xsl:if>
+              </xsl:for-each>
+            </xsl:variable>
+
             <form
               action="{$WebApplicationBaseURL}servlets/solr/find"
               class="searchfield_box form-inline my-2 my-lg-0"
@@ -73,7 +84,7 @@
                 type="text"
                 aria-label="Search" />
               <xsl:choose>
-                <xsl:when test="mcrxsl:isCurrentUserInRole('admin') or mcrxsl:isCurrentUserInRole('editor')">
+                <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
                   <input name="owner" type="hidden" value="createdby:*" />
                 </xsl:when>
                 <xsl:when test="not(mcrxsl:isCurrentUserGuestUser())">

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -72,7 +72,7 @@ MIR.Editor.HTML.Elements=%MIR.Editor.HTML.Elements% %MIR.Editor.MathML.Elements%
 MIR.OwnerStrategy.FallbackClass=org.mycore.mir.authorization.MIRStrategy
 # MIR.OwnerStrategy.ObjectTypes=mods,derivate
 # MIR.OwnerStrategy.AllowedPermissions=read,writedb
-
+MIR.OwnerStrategy.AllowedRolesForSearch=admin,editor
 
 ##############################################################################
 # Configure Index Browser                                                    #

--- a/mir-module/src/main/resources/xsl/layout/mir-common-layout.xsl
+++ b/mir-module/src/main/resources/xsl/layout/mir-common-layout.xsl
@@ -19,6 +19,7 @@
   <xsl:param name="MCR.Metadata.Languages" select="'de'" />
   <xsl:include href="layout/mir-layout-utils.xsl" />
   <xsl:include href="resource:xsl/layout/mir-navigation.xsl" />
+  <xsl:include href="resource:xsl/mir-utils.xsl" />
   <xsl:variable name="loaded_navigation_xml" select="layoutUtils:getPersonalNavigation()/navigation" />
   <xsl:variable name="browserAddress">
     <xsl:call-template name="getBrowserAddress" />

--- a/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
@@ -7,13 +7,11 @@
   xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
   xmlns:xalan="http://xml.apache.org/xalan"
   xmlns:exslt="http://exslt.org/common"
-  xmlns:str="http://exslt.org/strings"
-  exclude-result-prefixes="i18n mods xlink mcrxsl xalan exslt str"
+  exclude-result-prefixes="i18n mods xlink mcrxsl xalan exslt"
 >
 
-  <xsl:import href="xslImport:modsmeta:metadata/mir-abstract.xsl" />
-
-  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
+  <xsl:import  href="xslImport:modsmeta:metadata/mir-abstract.xsl" />
+  <xsl:include href="resource:xsl/mir-utils.xsl" />
 
   <xsl:variable name="objectID" select="/mycoreobject/@ID" />
   <xsl:variable name="modsPart" select="concat('mods.part.', $objectID)" />
@@ -21,23 +19,6 @@
   <xsl:template match="/">
 
     <xsl:variable name="mods" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods" />
-    <xsl:variable name="isSearchAllowedForCurrentUser">
-      <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
-        <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
-          <xsl:text>true</xsl:text>
-        </xsl:if>
-      </xsl:for-each>
-    </xsl:variable>
-    <xsl:variable name="owner">
-      <xsl:choose>
-        <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
-          <xsl:text>*</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$CurrentUser" />
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
 
     <!-- badges -->
     <div id="mir-abstract-badges">

--- a/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-abstract.xsl
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
-  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions" xmlns:xalan="http://xml.apache.org/xalan"
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:mods="http://www.loc.gov/mods/v3"
+  xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
+  xmlns:xalan="http://xml.apache.org/xalan"
   xmlns:exslt="http://exslt.org/common"
-  exclude-result-prefixes="i18n mods xlink mcrxsl xalan exslt"
+  xmlns:str="http://exslt.org/strings"
+  exclude-result-prefixes="i18n mods xlink mcrxsl xalan exslt str"
 >
 
   <xsl:import href="xslImport:modsmeta:metadata/mir-abstract.xsl" />
+
+  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:variable name="objectID" select="/mycoreobject/@ID" />
   <xsl:variable name="modsPart" select="concat('mods.part.', $objectID)" />
@@ -13,9 +21,16 @@
   <xsl:template match="/">
 
     <xsl:variable name="mods" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods" />
+    <xsl:variable name="isSearchAllowedForCurrentUser">
+      <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
+        <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
+          <xsl:text>true</xsl:text>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
     <xsl:variable name="owner">
       <xsl:choose>
-        <xsl:when test="mcrxsl:isCurrentUserInRole('admin') or mcrxsl:isCurrentUserInRole('editor')">
+        <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
           <xsl:text>*</xsl:text>
         </xsl:when>
         <xsl:otherwise>

--- a/mir-module/src/main/resources/xsl/mir-utils.xsl
+++ b/mir-module/src/main/resources/xsl/mir-utils.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
+    xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
+    xmlns:str="http://exslt.org/strings"
+    exclude-result-prefixes="i18n mcrxsl str"
+    >
+    
+    <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
+    
+    <xsl:variable name="isSearchAllowedForCurrentUser">
+        <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
+            <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
+                <xsl:text>true</xsl:text>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="owner">
+        <xsl:choose>
+            <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
+                <xsl:text>*</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$CurrentUser" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+</xsl:stylesheet>

--- a/mir-module/src/main/resources/xsl/response-mir-utils.xsl
+++ b/mir-module/src/main/resources/xsl/response-mir-utils.xsl
@@ -1,6 +1,8 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
   xmlns:encoder="xalan://java.net.URLEncoder" exclude-result-prefixes="xsl i18n encoder"
 >
+  
+  <xsl:include href="resource:xsl/mir-utils.xsl" />
 
   <xsl:template name="browse.Pagination">
     <xsl:param name="id" select="'pagination'" />

--- a/mir-module/src/main/resources/xsl/response-mir.xsl
+++ b/mir-module/src/main/resources/xsl/response-mir.xsl
@@ -19,7 +19,6 @@
   <xsl:param name="UserAgent" />
   <xsl:param name="MIR.testEnvironment" />
   <xsl:param name="MCR.ORCID.OAuth.ClientSecret" select="''" />
-  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:variable name="maxScore" select="//result[@name='response'][1]/@maxScore" />
 
@@ -719,24 +718,6 @@
                   </xsl:choose>
                 </xsl:variable>
                 <xsl:variable name="nameIdentifierAndType" select="substring-after(., ':')" />
-                <!-- if user is in role editor or admin, show all; other users only gets their own and published publications -->
-                <xsl:variable name="isSearchAllowedForCurrentUser">
-                  <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
-                    <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
-                      <xsl:text>true</xsl:text>
-                    </xsl:if>
-                  </xsl:for-each>
-                </xsl:variable>
-                <xsl:variable name="owner">
-                  <xsl:choose>
-                    <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
-                      <xsl:text>*</xsl:text>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:value-of select="$CurrentUser" />
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:variable>
                 <xsl:choose>
                   <xsl:when test="string-length($nameIdentifierAndType) &gt; 0">
                     <xsl:variable name="nameIdentifier" select="substring-after($nameIdentifierAndType, ':')" />

--- a/mir-module/src/main/resources/xsl/response-mir.xsl
+++ b/mir-module/src/main/resources/xsl/response-mir.xsl
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:encoder="xalan://java.net.URLEncoder"
-  xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation" xmlns:str="http://exslt.org/strings" xmlns:exslt="http://exslt.org/common" xmlns:mcr="xalan://org.mycore.common.xml.MCRXMLFunctions"
-  xmlns:acl="xalan://org.mycore.access.MCRAccessManager" xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions" xmlns:basket="xalan://org.mycore.frontend.basket.MCRBasketManager"
-  xmlns:decoder="xalan://java.net.URLDecoder" exclude-result-prefixes="i18n mods str exslt mcr acl mcrxsl basket encoder decoder"
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:mods="http://www.loc.gov/mods/v3"
+  xmlns:encoder="xalan://java.net.URLEncoder"
+  xmlns:i18n="xalan://org.mycore.services.i18n.MCRTranslation"
+  xmlns:str="http://exslt.org/strings"
+  xmlns:exslt="http://exslt.org/common"
+  xmlns:mcr="xalan://org.mycore.common.xml.MCRXMLFunctions"
+  xmlns:acl="xalan://org.mycore.access.MCRAccessManager"
+  xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
+  xmlns:basket="xalan://org.mycore.frontend.basket.MCRBasketManager"
+  xmlns:decoder="xalan://java.net.URLDecoder"
+  exclude-result-prefixes="i18n mods str exslt mcr acl mcrxsl basket encoder decoder"
 >
 
   <xsl:include href="response-mir-utils.xsl" />
@@ -10,6 +19,7 @@
   <xsl:param name="UserAgent" />
   <xsl:param name="MIR.testEnvironment" />
   <xsl:param name="MCR.ORCID.OAuth.ClientSecret" select="''" />
+  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:variable name="maxScore" select="//result[@name='response'][1]/@maxScore" />
 
@@ -710,17 +720,20 @@
                 </xsl:variable>
                 <xsl:variable name="nameIdentifierAndType" select="substring-after(., ':')" />
                 <!-- if user is in role editor or admin, show all; other users only gets their own and published publications -->
+                <xsl:variable name="isSearchAllowedForCurrentUser">
+                  <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
+                    <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
+                      <xsl:text>true</xsl:text>
+                    </xsl:if>
+                  </xsl:for-each>
+                </xsl:variable>
                 <xsl:variable name="owner">
                   <xsl:choose>
-                    <xsl:when test="mcrxsl:isCurrentUserInRole('admin') or mcrxsl:isCurrentUserInRole('editor')"><!--
-                      -->
-                      *<!--
-                    -->
+                    <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
+                      <xsl:text>*</xsl:text>
                     </xsl:when>
-                    <xsl:otherwise><!--
-                      -->
-                      <xsl:value-of select="$CurrentUser" /><!--
-                    -->
+                    <xsl:otherwise>
+                      <xsl:value-of select="$CurrentUser" />
                     </xsl:otherwise>
                   </xsl:choose>
                 </xsl:variable>

--- a/mir-module/src/main/resources/xsl/response-person.xsl
+++ b/mir-module/src/main/resources/xsl/response-person.xsl
@@ -17,20 +17,11 @@
 
   <xsl:param name="WebApplicationBaseURL" />
   <xsl:param name="MCR.Results.FetchHit" />
-  <xsl:param name="MIR.OwnerStrategy.AllowedRolesForSearch" select="'admin,editor'" />
 
   <xsl:decimal-format name="european" decimal-separator=',' grouping-separator='.' />
 
   <xsl:variable name="PageTitle">
     <xsl:value-of select="i18n:translate('component.solr.searchresult.resultList')" />
-  </xsl:variable>
-
-  <xsl:variable name="isSearchAllowedForCurrentUser">
-    <xsl:for-each select="str:tokenize($MIR.OwnerStrategy.AllowedRolesForSearch,',')">
-      <xsl:if test="mcrxsl:isCurrentUserInRole(.)">
-        <xsl:text>true</xsl:text>
-      </xsl:if>
-    </xsl:for-each>
   </xsl:variable>
   <xsl:variable name="numFound">
     <xsl:choose>
@@ -71,18 +62,6 @@
   </xsl:variable>
 
   <xsl:template match="lst[@name='mods.pindexname'] | lst[@name='mods.pindexname.published']">
-    <!-- if user is in role editor or admin, show all; other users only gets their own and published publications -->
-    <xsl:variable name="owner">
-      <xsl:choose>
-        <xsl:when test="contains($isSearchAllowedForCurrentUser, 'true')">
-          <xsl:text>*</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$CurrentUser" />
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-
     <xsl:for-each select="int">
       <xsl:sort select="@name" />
 


### PR DESCRIPTION
make allowed roles for search in non published documents configurable, using new property MIR.OwnerStrategy.AllowedRolesForSearch

[Link to jira](https://mycore.atlassian.net/browse/MIR-934).
