### PR TITLE
MIR-967 use property MIR.HostedPeriodicals.List to specify list of in

### DIFF
--- a/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/mir-module/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -44,6 +44,8 @@
   <xsl:param name="MCR.OAIDataProvider.RepositoryPublisherPlace" select="''" />
   <xsl:param name="MCR.OAIDataProvider.RepositoryPublisherAddress" select="''" />
   <xsl:param name="MCR.Metadata.DefaultLang" select="''" />
+  
+  <xsl:param name="MIR.HostedPeriodicals.List" select="''" />
 
   <xsl:variable name="languages" select="document('classification:metadata:-1:children:rfc5646')" />
   <xsl:variable name="marcrelator" select="document('classification:metadata:-1:children:marcrelator')" />
@@ -603,9 +605,14 @@
   </xsl:template>
 
   <xsl:template mode="relatedItem2source" match="mods:mods">
-      <!--  If not use isPartOf use dc:source -->
-    <xsl:if test="not(contains(mods:genre/@valueURI, 'issue') or contains(mods:genre/@valueURI, 'article'))">
-      <xsl:for-each select="mods:relatedItem[@type='host']">
+      <!--  For documents published as part of an publication use dc:source. For the relation to a periodical use dcterms:partOf -->
+    <xsl:for-each select="mods:relatedItem[@type='host' or @type='series']">
+      <xsl:variable name="is_hosted_periodical">
+        <xsl:call-template name="get_is_hosted_periodical" >
+          <xsl:with-param name="mycoreid" select="mods:relatedItem/@xlink:href"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:if test="$is_hosted_periodical='false'">
         <xsl:variable name="hosttitel" select="mods:titleInfo/mods:title" />
         <xsl:variable name="issue" select="mods:part/mods:detail[@type='issue']/mods:number" />
         <xsl:variable name="volume" select="mods:part/mods:detail[@type='volume']/mods:number" />
@@ -629,8 +636,9 @@
         <dc:source xsi:type="ddb:noScheme">
           <xsl:value-of select="concat($hosttitel,$volume2,$issue2,$pages)" />
         </dc:source>
-      </xsl:for-each>
-    </xsl:if>
+      </xsl:if>
+    </xsl:for-each>
+    
   </xsl:template>
 
   <xsl:template name="language">
@@ -639,39 +647,50 @@
     </dc:language>
   </xsl:template>
 
-<!-- dcterms:isPartOf xsi:type="ddb:Erstkat-ID" >2049984-X</dcterms:isPartOf>
-<dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe" >2004</dcterms:isPartOf -->
+  <!-- dcterms:isPartOf xsi:type="ddb:Erstkat-ID" >2049984-X</dcterms:isPartOf>
+  <dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe" >2004</dcterms:isPartOf -->
   <xsl:template mode="relatedItem2ispartof" match="mods:mods">
       <!-- Ausgabe der Schriftenreihe ala: <dcterms:isPartOf xsi:type=“ddb:noScheme“>Bulletin ; 34</dcterms:isPartOf>  -->
-    <xsl:if test="mods:relatedItem/@type='series'">
-      <dcterms:isPartOf xsi:type="ddb:noScheme">
-        <xsl:value-of select="mods:relatedItem[@type='series']/mods:titleInfo/mods:title" />
-        <xsl:if test="mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number">
-          <xsl:value-of select="concat(' ; ',mods:relatedItem[@type='series']/mods:part/mods:detail[@type='volume']/mods:number)" />
-        </xsl:if>
-      </dcterms:isPartOf>
-    </xsl:if>
-    <xsl:if test="contains(mods:genre/@valueURI, 'issue') or contains(mods:genre/@valueURI, 'article')">
-      <dcterms:isPartOf xsi:type="ddb:ZSTitelID">
-        <xsl:value-of select="mods:relatedItem[@type='host']/@xlink:href" />
-      </dcterms:isPartOf>
-      <xsl:if test="mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']">
-        <dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe">
-          <xsl:choose>
-            <xsl:when test="mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']">
-              <xsl:value-of
-                select="concat(normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume']),
-                  ', ',
-                  i18n:translate('component.mods.metaData.dictionary.issue'),
-                  ' ',
-                  normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='issue']))" />
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="normalize-space(mods:relatedItem[@type='host']/mods:part/mods:detail[@type='volume'])" />
-            </xsl:otherwise>
-          </xsl:choose>
-        </dcterms:isPartOf>
-      </xsl:if>
+      <!-- isPartOf is the relation to an periodical eg. journal, series. For relation to nonperiodical use dc:source  -->
+    <xsl:variable name="firstPeriodical" select="mods:relatedItem[@type='series' or (@type='host' and (contains(mods:genre/@valueURI,'journal') or contains(mods:genre/@valueURI,'series')) )][1]" />
+    <xsl:if test="$firstPeriodical">
+      <xsl:variable name="is_hosted_periodical">
+        <xsl:call-template name="get_is_hosted_periodical" >
+          <xsl:with-param name="mycoreid" select="mods:relatedItem/@xlink:href"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:choose>
+        <xsl:when test="$is_hosted_periodical = 'true' and $firstPeriodical/@type='host'">
+          <dcterms:isPartOf xsi:type="ddb:ZSTitelID">
+            <xsl:value-of select="$firstPeriodical/@xlink:href" />
+          </dcterms:isPartOf>
+          <xsl:if test="$firstPeriodical/mods:part/mods:detail[@type='volume']">
+            <dcterms:isPartOf xsi:type="ddb:ZS-Ausgabe">
+              <xsl:choose>
+                <xsl:when test="$firstPeriodical/mods:part/mods:detail[@type='issue']">
+                  <xsl:value-of
+                    select="concat(normalize-space($firstPeriodical/mods:part/mods:detail[@type='volume']),
+                      ', ',
+                      i18n:translate('component.mods.metaData.dictionary.issue'),
+                      ' ',
+                      normalize-space($firstPeriodical/mods:part/mods:detail[@type='issue']))" />
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="normalize-space($firstPeriodical/mods:part/mods:detail[@type='volume'])" />
+                </xsl:otherwise>
+              </xsl:choose>
+            </dcterms:isPartOf>
+          </xsl:if>
+        </xsl:when>
+        <xsl:when test="$is_hosted_periodical = 'true' and $firstPeriodical/@type='series'">
+          <dcterms:isPartOf xsi:type="ddb:noScheme">
+            <xsl:value-of select="$firstPeriodical/mods:titleInfo/mods:title" /> 
+            <xsl:if test="$firstPeriodical/mods:part/mods:detail[@type='volume']/mods:number">
+              <xsl:value-of select="concat(' ; ',$firstPeriodical/mods:part/mods:detail[@type='volume']/mods:number)" />
+            </xsl:if>
+          </dcterms:isPartOf>
+        </xsl:when>
+      </xsl:choose>
     </xsl:if>
   </xsl:template>
 
@@ -782,6 +801,22 @@
       </xsl:when>
       <xsl:otherwise>
         <ddb:rights ddb:kind="domain" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <xsl:template name="get_is_hosted_periodical">
+    <!-- Test for journals or series hosted/published by this repository (eg. Zeitschriftenserver)  -->
+    <xsl:param name="mycoreid"/>
+    <xsl:choose>
+      <xsl:when test="not($mycoreid) or $mycoreid = ''">
+        <xsl:value-of select="'false'"/>
+      </xsl:when>
+      <xsl:when test="contains($MIR.HostedPeriodicals.List,$mycoreid)">
+        <xsl:value-of select="'true'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'false'"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
... repository hosted periodicals

[Link to jira](https://mycore.atlassian.net/browse/MIR-967).

Here an example for property usage:

MIR.HostedPeriodicals.List=zimport_mods_00000280,zimport_mods_00000282,zimport_mods_00000283,zimport_mods_00000284,zimport_mods_00000286,zimport_mods_00000288,zimport_mods_00000285,clausthal_mods_00000082