### PR TITLE
MIR-847 do not use MCRSolrCategoryDAO in jUnitTests

### DIFF
--- a/mir-module/src/test/resources/mycore.properties
+++ b/mir-module/src/test/resources/mycore.properties
@@ -1,2 +1,3 @@
 #do not use SOLR for JUnit-Tests
 MCR.Category.LinkService=org.mycore.datamodel.classifications2.impl.MCRCategLinkServiceImpl
+MCR.Category.DAO=


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-847).
