### PR TITLE
MIR-985 add extended test to check accesskey fallbackrule for derivates

### DIFF
--- a/mir-module/src/test/resources/MIRStrategyTest/class/mcr-roles.xml
+++ b/mir-module/src/test/resources/MIRStrategyTest/class/mcr-roles.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mycoreclass xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="MCRClassification.xsd" ID="mcr-roles">
+  <label xml:lang="en" text="system user roles" />
+  <label xml:lang="de" text="Systemnutzerrollen" />
+  <label xml:lang="x-uri" text="http://www.mycore.org/classifications/mcr-roles" />
+  <categories>
+    <category ID="admin">
+      <label xml:lang="en" text="Administrator" />
+      <label xml:lang="de" text="Administrator" />
+    </category>
+    <category ID="editor">
+      <label xml:lang="en" text="Editor" />
+      <label xml:lang="de" text="Bearbeiter" />
+    </category>
+    <category ID="submitter">
+      <label xml:lang="en" text="Author" />
+      <label xml:lang="de" text="Autoren" />
+    </category>
+    <category ID="reader">
+      <label xml:lang="de" text="Leser" />
+      <label xml:lang="en" text="Reader" />
+    </category>
+    <category ID="restapi">
+      <label xml:lang="de" text="Schreibender Zugriff für REST-API" />
+      <label xml:lang="en" text="Write Access to REST-API" />
+    </category>
+  </categories>
+</mycoreclass>


### PR DESCRIPTION
NOTE: requires to define rule mapping for ID "derivate:mir_access:accessKey"

[Link to jira](https://mycore.atlassian.net/browse/MIR-985).
