### PR TITLE
MIR-986 Can not import DeepGreen

### DIFF
--- a/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
+++ b/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
@@ -344,7 +344,7 @@
   </xsl:template>
 
   <!-- Reduce ORCID iDs given as complete URL -->
-  <xsl:template match="contrib-id[contains('orcid.org/')]" priority="1">
+  <xsl:template match="contrib-id[contains(.,'orcid.org/')]" priority="1">
     <mods:nameIdentifier type="orcid">
       <xsl:value-of select="substring-after(.,'orcid.org/')" />
     </mods:nameIdentifier>


### PR DESCRIPTION
fixed jats2mods.xsl

[Link to jira](https://mycore.atlassian.net/browse/MIR-986).
