### PR TITLE
MIR-1030 Fixed display of licenses in the info box

### DIFF
--- a/mir-module/src/main/resources/xsl/metadata/mir-citation.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-citation.xsl
@@ -216,7 +216,7 @@
                   mode="ogl-logo" />
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods/mods:accessCondition[@type='use and reproduction']" />
+                <xsl:value-of select="document(concat('classification:metadata:0:children:mir_licenses:', $trimmed))/mycoreclass/categories/category[@ID=$trimmed]/label[@xml:lang=$CurrentLang]/@text" />
               </xsl:otherwise>
             </xsl:choose>
           </p>


### PR DESCRIPTION
The value selection in the otherwise block was not working.
I've changed the selection to classification request so that text
description is used in the otherwise case.

[Link to jira](https://mycore.atlassian.net/browse/MIR-1030).
