### PR TITLE
MIR-1035 Exclude genre types from validation

### DIFF
--- a/mir-module/src/main/resources/META-INF/resources/editor/editor-includes.xed
+++ b/mir-module/src/main/resources/META-INF/resources/editor/editor-includes.xed
@@ -2187,8 +2187,8 @@
     <xed:load-resource name="mir_genres" uri="classification:metadata:-1:children:mir_genres" />
     <xed:validate xpath="//mods:mods/mods:genre[@authorityURI=$mir_genres/label[@xml:lang='x-uri']/@text]/@valueURIxEditor" required="true"
       i18n="mir.validation.genre" display="global" />
-    <!-- don't validate author, date issued and rights for journal etc.  -->
-    <xed:if test="//mods:mods/mods:genre[@valueURIxEditor!='journal'][@valueURIxEditor!='newspaper'][@valueURIxEditor!='series'][@valueURIxEditor!='lecture'][@valueURIxEditor!='blog']">
+    <!-- don't validate rights for specified genres configured in MIR.Editor.Validate.Genre.Licence -->
+    <xed:if test="//mods:mods/mods:genre[not(contains(concat(' ',$MIR.Editor.Validate.Genre.Licence,' '),concat(' ',@valueURIxEditor,' ')))]">
       <xed:validate xpath="//mods:mods/mods:accessCondition[@type='use and reproduction']" required="true" i18n="mir.validation.rights" display="global" />
     </xed:if>
 

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -450,11 +450,11 @@ MCR.Jersey.Resource.Packages=%MCR.Jersey.Resource.Packages%,org.mycore.mir.stati
 
 
 ##############################################################################
-# Xeditor                                                                    #
+# xEditor                                                                    #
 ##############################################################################
 
 # exclude genres from licence validation
-MIR.Editor.Validate.Genre.Licence = journal newspaper series lecture blog
+MIR.Editor.Validate.Genre.Licence=journal newspaper series lecture blog
 
 # Geographic coordinates
 MIR.editor.start.coordinates.lat=50.930453

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -450,8 +450,13 @@ MCR.Jersey.Resource.Packages=%MCR.Jersey.Resource.Packages%,org.mycore.mir.stati
 
 
 ##############################################################################
-# Geographic coordinates                                                     #
+# Xeditor                                                                    #
 ##############################################################################
+
+# exclude genres from licence validation
+MIR.Editor.Validate.Genre.Licence = journal newspaper series lecture blog
+
+# Geographic coordinates
 MIR.editor.start.coordinates.lat=50.930453
 MIR.editor.start.coordinates.lon=11.587786
 


### PR DESCRIPTION
Added a new mycore property which makes it possible to exclude genre types
from xeditor validation.

[Link to jira](https://mycore.atlassian.net/browse/MIR-1035).
