### PR TITLE
MIR-1047 Add option to include icon in panels rendered by the new Metadata Layout

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -601,6 +601,11 @@ MIR.Layout.Bottom=
 MIR.Layout.Display.Panel=mir-access-rights,mir-export,mir-admindata,mir-citation
 MIR.Layout.Display.Div=mir-edit,mir-abstract-badges
 
+#MIR.Layout.Display.Panel.Icon.mir-access-rights=fas fa-gavel
+#MIR.Layout.Display.Panel.Icon.mir-export=fas fa-share-square
+#MIR.Layout.Display.Panel.Icon.mir-admindata=fas fa-info-circle
+#MIR.Layout.Display.Panel.Icon.mir-citation=fas fa-quote-right
+
 MIR.NotFullAccessInfo.Genres=
 
 ##############################################################################

--- a/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:mcri18n="http://www.mycore.de/xslt/i18n"
+                xmlns:mcrproperty="http://www.mycore.de/xslt/property"
                 version="3.0">
 
   <xsl:include href="functions/i18n.xsl" />
+  <xsl:include href="functions/property.xsl" />
 
   <xsl:param name="MIR.Layout.Top"/>
   <xsl:param name="MIR.Layout.End"/>
@@ -73,6 +75,7 @@
     <xsl:param name="properties"/>
 
     <xsl:variable name="originalContent" select="."/>
+    <xsl:variable name="icons" select="mcrproperty:all('MIR.Layout.Display.Panel.Icon')" />
     <xsl:for-each select="tokenize($properties, ',')">
       <xsl:variable name="boxID" select="normalize-space(.)"/>
       <xsl:if test="count($originalContent/div[@id=$boxID])&gt;=1">
@@ -168,6 +171,10 @@
             <div class="card" id="{concat($boxID, '-panel')}">
               <div class="card-header">
                 <h3 class="card-title">
+                  <xsl:variable name="icon" select="$icons/entry[@key=concat('MIR.Layout.Display.Panel.Icon.', $boxID)]" />
+                  <xsl:if test="$icon">
+                    <i class="{$icon/text()}" style="margin-right:1ex;" aria-hidden="true" />
+                  </xsl:if>
                   <xsl:value-of
                       select="mcri18n:translate(concat('mir.metaData.panel.heading.', $boxID))"/>
                 </h3>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1047).

Depends upon [MCR-2464](https://github.com/MyCoRe-Org/mycore/pull/1320).

This pull request only adds the option to include icons in panels rendered by the new Metadata Layout. Actually using this feature requires changes to the configuration. Example configuration is provided but commented out, so the default behavior of MIR is unaffected.
