### PR TITLE
MIR-1081 fixes lost classes when dropdown menu entry gets active

### DIFF
--- a/mir-module/src/main/resources/xsl/layout/mir-common-layout.xsl
+++ b/mir-module/src/main/resources/xsl/layout/mir-common-layout.xsl
@@ -54,7 +54,7 @@
         <li class="nav-item dropdown">
           <xsl:if test="$loaded_navigation_xml/menu[@id='user']//item[@href = $browserAddress ]">
             <xsl:attribute name="class">
-              <xsl:value-of select="'active'" />
+              <xsl:value-of select="'nav-item dropdown active'" />
             </xsl:attribute>
           </xsl:if>
           <a id="currentUser" class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">


### PR DESCRIPTION
Not sure, is this the correct branch to fix?
xasia seems to run on 2020.06
