### PR TITLE
MIR-1142 Change MIROrcidServlet character encoding to UTF-8

### DIFF
--- a/mir-module/src/main/java/org/mycore/mir/orcid/MIROrcidServlet.java
+++ b/mir-module/src/main/java/org/mycore/mir/orcid/MIROrcidServlet.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -127,7 +128,8 @@ public class MIROrcidServlet extends MCRServlet {
         HttpServletResponse resp = job.getResponse();
         ServletOutputStream outputStream = resp.getOutputStream();
         resp.setContentType("application/json");
-        outputStream.print(json);
+        resp.setCharacterEncoding("UTF-8");
+        outputStream.write(json.getBytes(StandardCharsets.UTF_8));
         outputStream.flush();
         outputStream.close();
     }


### PR DESCRIPTION
JSON sent over the internet must be encoded as UTF-8 as per RFC 8259.
This commit changes the character encoding of the MIROrcidServlet from
ISO-8859-1 to UTF-8, fixing the display of special characters in the
browser.

[Link to jira](https://mycore.atlassian.net/browse/MIR-1142).
