### PR TITLE
MIR-1149 Use global proxy for OpenAIRE

### DIFF
--- a/mir-module/src/main/java/org/mycore/mir/MIRGetOpenAIREProjectsServlet.java
+++ b/mir-module/src/main/java/org/mycore/mir/MIRGetOpenAIREProjectsServlet.java
@@ -32,7 +32,7 @@ public class MIRGetOpenAIREProjectsServlet extends HttpServlet {
     public void init() throws ServletException {
         PoolingHttpClientConnectionManager connectManager = new PoolingHttpClientConnectionManager();
         connectManager.setDefaultMaxPerRoute(20);
-        client = HttpClients.custom().setConnectionManager(connectManager).build();
+        client = HttpClients.custom().useSystemProperties().setConnectionManager(connectManager).build();
     }
 
     @Override


### PR DESCRIPTION
Make MIRGetOpenAIREProjectsServlet use the global proxy set via Java's
system properties ("https.proxyHost" etc.) when it constructs its Apache
HTTP Client.

[Link to jira](https://mycore.atlassian.net/browse/MIR-1149).
