### PR TITLE
MIR-1156 Unnecessary margin causes premature line breaks

### DIFF
--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_metadata.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_metadata.scss
@@ -266,7 +266,6 @@ $grayDark: #ECF0F1 !default;
 }
 .mir-toc-section-label {
   display: inline-block;
-  margin-right: 1ex;
 }
 .mir-toc-section-list {
   list-style: none;


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1156).
