### PR TITLE
MIR-1096 Add highly visible edit button for metadata

### DIFF
--- a/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_details.scss
+++ b/mir-layout/src/main/resources/META-INF/resources/mir-layout/scss/common/mir_details.scss
@@ -10,6 +10,11 @@
     border-bottom: 1px solid #ddd;
   }
 
+  .detail_buttons {
+    float: right;
+    margin-top: -8px;
+  }
+
   .ellipsis {
     max-height: 150px;
   }
@@ -61,14 +66,10 @@
 }
 
 .mir_metadata {
-  overflow: hidden;
   margin-bottom: 30px;
-  h3 {
-    font-size: 16px;
-    margin-top: 0;
-    margin-bottom: 20px;
-    padding-bottom: 5px;
-    border-bottom: 1px solid #ddd;
+
+  dl {
+    margin-top: 20px;
   }
 
   dt {

--- a/mir-module/src/main/resources/config/mir/messages_de.properties
+++ b/mir-module/src/main/resources/config/mir/messages_de.properties
@@ -437,6 +437,7 @@ mir.metaData.panel.heading.mir-epusta           = Zugriffsstatistik
 mir.metaData.panel.heading.mir-export           = Export
 mir.metaData.panel.heading.mir_admindata_panel  = Systeminformation
 mir.metadata.content                            = Inhalt
+mir.metadata.help                               = In Abh\u00E4ngigkeit vom gew\u00E4hlten Publikationstyp, k\u00F6nnen Sie unterschiedliche Metadaten f\u00FCr die Ver\u00F6ffentlichung eingeben.
 mir.metadata.isReferencedBy                     = Referenziert von
 mir.metadata.otherVersion                       = Andere Version
 mir.metadata.review                             = Rezension

--- a/mir-module/src/main/resources/config/mir/messages_en.properties
+++ b/mir-module/src/main/resources/config/mir/messages_en.properties
@@ -429,6 +429,7 @@ mir.metaData.panel.heading.mir-epusta          = Access Statistic
 mir.metaData.panel.heading.mir-export          = Export
 mir.metaData.panel.heading.mir_admindata_panel = System Information
 mir.metadata.content                           = Content
+mir.metadata.help                              = Depending on the publication type you can enter different metadata for the publication.
 mir.metadata.isReferencedBy                    = Referenced by
 mir.metadata.otherVersion                      = Other version
 mir.metadata.review                            = Review

--- a/mir-module/src/main/resources/xsl/metadata/mir-metadata-box.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-metadata-box.xsl
@@ -11,6 +11,27 @@
   <xsl:key use="@type" name="title-by-type" match="//mods:mods/mods:titleInfo" />
 
   <xsl:template match="/">
+    <div id="mir-metadata-buttons">
+      <xsl:if test="key('rights', mycoreobject/@ID)/@write">
+        <xsl:variable name="editURL">
+          <xsl:call-template name="mods.getObjectEditURL">
+            <xsl:with-param name="id" select="mycoreobject/@ID"/>
+            <xsl:with-param name="layout" select="'$'"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <div class="detail_buttons">
+          <div class="btn-group btn-group-sm">
+            <a class="btn btn-light " data-content="{i18n:translate('mir.metadata.help')}" data-placement="top" data-toggle="popover" role="button"
+               tabindex="0" data-original-title="" title="">
+              <i class="fas fa-info fa-fw"/>
+            </a>
+            <a id="derivate-toggle-button" class="btn btn-success" href="{$editURL}">
+              <i class="fas fa-pencil-alt fa-fw"/>
+            </a>
+          </div>
+        </div>
+      </xsl:if>
+    </div>
     <xsl:variable name="mods" select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods" />
     <!-- $mods-type contains genre -->
     <div id="mir-metadata">

--- a/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mods-metadata-page.xsl
@@ -148,20 +148,23 @@
             </xsl:if>
           </xsl:when>
           <xsl:when test="$boxID='mir-metadata'">
-            <div class="mir_metadata">
-              <h3>
-                <xsl:value-of
-                    select="mcri18n:translate('component.mods.metaData.dictionary.categorybox')"/>
-              </h3>
-              <!-- Start: METADATA -->
-              <xsl:apply-templates select="$originalContent/div[@id=$boxID]" mode="newMetadata"/>
-              <!-- End: METADATA -->
-              <xsl:if
-                  test="$originalContent/div[@id=$boxID]/table[@class='mir-metadata']/tr/td/div[contains(@class,'openstreetmap-container')]">
-                <link rel="stylesheet" type="text/css" href="{$WebApplicationBaseURL}assets/openlayers/ol.css"/>
-                <script type="text/javascript" src="{$WebApplicationBaseURL}assets/openlayers/ol.js"/>
-                <script type="text/javascript" src="{$WebApplicationBaseURL}js/mir/geo-coords.min.js"></script>
-              </xsl:if>
+            <div class="detail_block">
+              <div class="mir_metadata">
+                <xsl:copy-of select="$originalContent/div[@id='mir-metadata-buttons']/*" />
+                <h3>
+                  <xsl:value-of
+                      select="mcri18n:translate('component.mods.metaData.dictionary.categorybox')"/>
+                </h3>
+                <!-- Start: METADATA -->
+                <xsl:apply-templates select="$originalContent/div[@id=$boxID]" mode="newMetadata"/>
+                <!-- End: METADATA -->
+                <xsl:if
+                    test="$originalContent/div[@id=$boxID]/table[@class='mir-metadata']/tr/td/div[contains(@class,'openstreetmap-container')]">
+                  <link rel="stylesheet" type="text/css" href="{$WebApplicationBaseURL}assets/openlayers/ol.css"/>
+                  <script type="text/javascript" src="{$WebApplicationBaseURL}assets/openlayers/ol.js"/>
+                  <script type="text/javascript" src="{$WebApplicationBaseURL}js/mir/geo-coords.min.js"></script>
+                </xsl:if>
+              </div>
             </div>
           </xsl:when>
           <xsl:when test="$boxID='mir-abstract-plus'">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1096).

**Some notes:**

In order to get rid of the `style` attributes and to provide reusable style classes I've made the following changes:

- placed `mir_metadata` element inside a `detail_block` element
- removed superfluous `overflow`  property from the styling of `.mir_metadata`
- removed the now duplicated `h3` styling (`.mir_metadata h3` is now mostly covered by `.detail_block h3`) in `mir_details.scss`, moving the only difference ( a `20px` bottom margin) to `.mir_metadata dt` (as a `20px` top margin)
- added reusable `.detail_buttons` class that can be used to add a button group to any `.detail_block`
