### PR TITLE
MIR-1175 repair MIR-Wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This guide addresses developers. Thats why you run it in 'dev' profile!
   - stop solr with the command: `mvn -Pdev solr-runner:stop`
   - update solr with the command: `mvn -Pdev solr-runner:stop solr-runner:copyHome solr-runner:start`
  - to starting up a servlet container in development environment go back to mir folder
-  - run `mvn install -am -pl mir-webapp && mvn -Pdev -Djetty org.codehaus.cargo:cargo-maven2-plugin:run -pl mir-webapp` If you want to test the application with Tomcat instead replace `-Djetty` by `-Dtomcat=9`
+  - run `mvn install -am -pl mir-webapp && mvn -Pdev -Dtomcat org.codehaus.cargo:cargo-maven2-plugin:run -pl mir-webapp`
 
 ## FAQ
  1. Installation hangs while generating secret  

--- a/mir-wizard/src/main/java/org/mycore/mir/wizard/command/MIRWizardDownloadDBLib.java
+++ b/mir-wizard/src/main/java/org/mycore/mir/wizard/command/MIRWizardDownloadDBLib.java
@@ -23,17 +23,15 @@
 package org.mycore.mir.wizard.command;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.net.URL;
-import java.net.URLClassLoader;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdom2.Element;
-import org.mycore.common.MCRClassTools;
 import org.mycore.common.config.MCRConfigurationDir;
+import org.mycore.common.config.MCRConfigurationDirSetup;
 import org.mycore.mir.wizard.MIRWizardCommand;
 
 public class MIRWizardDownloadDBLib extends MIRWizardCommand {
@@ -63,7 +61,7 @@ public class MIRWizardDownloadDBLib extends MIRWizardCommand {
                 try {
 
                     FileUtils.copyURLToFile(new URL(url), file);
-                    loadLib(file.toURI().toURL());
+                    MCRConfigurationDirSetup.loadExternalLibs();
 
                     success = true;
                 } catch (Exception ex) {
@@ -82,14 +80,5 @@ public class MIRWizardDownloadDBLib extends MIRWizardCommand {
 
             this.result.setSuccess(success);
         }
-    }
-
-    private void loadLib(URL jarFile) throws ReflectiveOperationException {
-        URLClassLoader sysloader = (URLClassLoader) MCRClassTools.getClassLoader();
-        Class<URLClassLoader> sysclass = URLClassLoader.class;
-
-        Method method = sysclass.getDeclaredMethod("addURL", URL.class);
-        method.setAccessible(true);
-        method.invoke(sysloader, new Object[] { jarFile });
     }
 }

--- a/mir-wizard/src/main/resources/config/mir-wizard/mycore.properties
+++ b/mir-wizard/src/main/resources/config/mir-wizard/mycore.properties
@@ -9,3 +9,4 @@ MIR.Wizard.LayoutStylesheet=xsl/mir-wizard-layout.xsl
 ######################################################################
 
 MCR.Startup.Class=org.mycore.mir.wizard.MIRWizardStartupHandler,%MCR.Startup.Class%
+MCR.LayoutService.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl

--- a/mir-wizard/src/main/resources/setup/template-persistence.xml
+++ b/mir-wizard/src/main/resources/setup/template-persistence.xml
@@ -5,7 +5,6 @@
              version="2.2">
   <persistence-unit name="MyCoRe" transaction-type="RESOURCE_LOCAL">
     <mapping-file>META-INF/mycore-base-mappings.xml</mapping-file>
-    <mapping-file>META-INF/mycore-ifs-mappings.xml</mapping-file>
     <mapping-file>META-INF/mycore-iview2-mappings.xml</mapping-file>
     <mapping-file>META-INF/mycore-pi-mappings.xml</mapping-file>
     <mapping-file>META-INF/mycore-user2-mappings.xml</mapping-file>
@@ -13,10 +12,10 @@
     <!-- required for MIR only: -->
     <mapping-file>META-INF/mir-module-mappings.xml</mapping-file>
     <properties>
-      <property name="javax.persistence.jdbc.driver" />
-      <property name="javax.persistence.jdbc.url" />
-      <property name="javax.persistence.jdbc.user" />
-      <property name="javax.persistence.jdbc.password" />
+      <property name="jakarta.persistence.jdbc.driver" />
+      <property name="jakarta.persistence.jdbc.url" />
+      <property name="jakarta.persistence.jdbc.user" />
+      <property name="jakarta.persistence.jdbc.password" />
       <property name="hibernate.cache.use_second_level_cache" value="false" />
       <property name="hibernate.hbm2ddl.auto" value="validate" />
       <property name="hibernate.default_schema" />

--- a/mir-wizard/src/main/resources/xsl/wizard-orm.xsl
+++ b/mir-wizard/src/main/resources/xsl/wizard-orm.xsl
@@ -26,7 +26,7 @@
         <xsl:when test="name() = 'persistence-unit-defaults'">
           <xsl:if test="xalan:nodeset($cfg)//extra_properties//property[contains('schema|catalog', @name)]">
             <xsl:for-each select="xalan:nodeset($cfg)//extra_properties//property[contains('schema|catalog', @name)]">
-              <xsl:element name="{@name}" xmlns="http://java.sun.com/xml/ns/persistence/orm">
+              <xsl:element name="{@name}" xmlns="http://xmlns.jcp.org/xml/ns/persistence">
                 <xsl:value-of select="." />
               </xsl:element>
             </xsl:for-each>


### PR DESCRIPTION
- use MCRConfigurationDirSetup.loadExternalLibs() instead of reflection to load new driver lib
- fixed generated persistence.xml
- updated README.md to use tomcat instead of jetty

[Link to jira](https://mycore.atlassian.net/browse/MIR-1175).
