### PR TITLE
MIR-1182 mods2dc xsl generates invalid ids

### DIFF
--- a/mir-module/src/main/resources/xsl/mods2dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2dc.xsl
@@ -60,7 +60,7 @@
 
   <xsl:template match="/">
 
-    <xsl:variable name="objId" select="@ID" />
+    <xsl:variable name="objId" select="mods:mods/@ID" />
 
     <xsl:choose>
       <!-- WS: updated schema location -->


### PR DESCRIPTION
fix xslt expression to correctly fetch the document's id

[Link to jira](https://mycore.atlassian.net/browse/MIR-1182).
