### PR TITLE
MIR-1183 mod2dc.xsl coverage ranges should use iso format

### DIFF
--- a/mir-module/src/main/resources/xsl/mods2dc-mode-dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2dc-mode-dc.xsl
@@ -221,7 +221,7 @@
       <dc:coverage>
         <xsl:for-each select="mods:temporal">
           <xsl:value-of select="."/>
-          <xsl:if test="position()!=last()">-</xsl:if>
+          <xsl:if test="position()!=last()">/</xsl:if>
         </xsl:for-each>
       </dc:coverage>
     </xsl:if>

--- a/mir-module/src/main/resources/xsl/mods2dc.xsl
+++ b/mir-module/src/main/resources/xsl/mods2dc.xsl
@@ -247,7 +247,7 @@
       <dc:coverage>
         <xsl:for-each select="mods:temporal">
           <xsl:value-of select="."/>
-          <xsl:if test="position()!=last()">-</xsl:if>
+          <xsl:if test="position()!=last()">/</xsl:if>
         </xsl:for-each>
       </dc:coverage>
     </xsl:if>


### PR DESCRIPTION
change the mods2dc stylesheets to use "/" iso date separators

[Link to jira](https://mycore.atlassian.net/browse/MIR-1183).
