### PR TITLE
MIR-1213 update jats2mods.xsl to xslt 3 and add thulb fixes

### DIFF
--- a/mir-module/src/main/java/org/mycore/mir/sword2/MIRDeepGreepIngester.java
+++ b/mir-module/src/main/java/org/mycore/mir/sword2/MIRDeepGreepIngester.java
@@ -22,7 +22,10 @@ import org.mycore.access.MCRAccessException;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.function.MCRThrowFunction;
+import org.mycore.datamodel.classifications2.MCRCategoryDAOFactory;
+import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.metadata.MCRDerivate;
+import org.mycore.datamodel.metadata.MCRMetaClassification;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
 import org.mycore.datamodel.metadata.MCRObject;
 import org.mycore.datamodel.metadata.MCRObjectID;
@@ -88,6 +91,17 @@ public class MIRDeepGreepIngester extends MIRSwordIngesterBase {
                     final MCRDerivate derivate = MCRSwordUtil.createDerivate(resultingObject.getId().toString());
                     Files.copy(pdfIS, MCRPath.getPath(derivate.getId().toString(), fileName));
                     derivate.getDerivate().getInternals().setMainDoc(fileName);
+                    MCRCategoryID derivateTypeId = new MCRCategoryID("derivate_types", "content");
+                    if (MCRCategoryDAOFactory.getInstance().exist(derivateTypeId)) {
+                        MCRMetaClassification derivateTypeClassification = new MCRMetaClassification(
+                            "classification",
+                            0,
+                            null,
+                            derivateTypeId.getRootID(),
+                            derivateTypeId.getID()
+                        );
+                        derivate.getDerivate().getClassifications().add(derivateTypeClassification);
+                    }
                     MCRMetadataManager.update(derivate);
                     return newObjectId;
                 } catch (SAXException | JDOMException | MCRAccessException e) {

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -462,13 +462,20 @@ MCR.GoogleSitemap.SolrQuery=worldReadable:true AND ((objectType:mods AND -state:
 # MCR.ContentTransformer.goobidc2mods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 # MCR.ContentTransformer.goobidc2mods.Stylesheet=xsl/DC_MODS3-5_XSLT1-0.xsl
 
-# Deep Green
-# MCR.Sword.Collection.MyWorkspace.DefaultDeepGreen = org.mycore.mir.sword2.MIRDeepGreenCollectionProvider
-# MCR.Sword.DefaultDeepGreen.Transformer = deepgreenjats2mods
-# MCR.Sword.DefaultDeepGreen.State = imported
 
+# Deep Green
+# MCR.Sword.Collection.MyWorkspace.DefaultDeepGreen=org.mycore.mir.sword2.MIRDeepGreenCollectionProvider
+# MCR.Sword.DefaultDeepGreen.Transformer=deepgreenjats2mods
+# MCR.Sword.DefaultDeepGreen.State=imported
+
+# MCR.ContentTransformer.deepgreenjats2mods.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
 # MCR.ContentTransformer.deepgreenjats2mods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 # MCR.ContentTransformer.deepgreenjats2mods.Stylesheet=xsl/sword/jats2mods.xsl
+
+# When set to "embed", related host publication (journal) will be embedded.
+# When set to "link", related host publication (journal) will be created and/or linked via @xlink:href.
+# MCR.ContentTransformer.deepgreenjats2mods.HostRelation=link
+
 
 # Dissemin
 # MCR.Sword.Collection.MyWorkspace.dissemin = org.mycore.mir.sword2.MIRDisseminCollectionProvider

--- a/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
+++ b/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
@@ -352,12 +352,10 @@
 
   <xsl:template match="*" mode="copy-affiliation" />
 
-  <xsl:template match="contrib-id">
-    <xsl:if test="text() != ''">
-      <mods:nameIdentifier type="{@contrib-id-type}">
-        <xsl:value-of select="." />
-      </mods:nameIdentifier>
-    </xsl:if>
+  <xsl:template match="contrib-id" priority="1">
+    <mods:nameIdentifier type="{@contrib-id-type}">
+      <xsl:value-of select="." />
+    </mods:nameIdentifier>
   </xsl:template>
   
   <xsl:variable name="orcidSite">orcid.org/</xsl:variable>
@@ -371,7 +369,9 @@
   </xsl:template>
 
   <!-- Ignore empty ORCIDs -->
-  <xsl:template match="contrib-id[contains(.,$orcidSite)][normalize-space(substring-after(.,$orcidSite)) = '']" priority="2" />
+  <xsl:template match="contrib-id[(normalize-space() = '')
+    or (contains(., $orcidSite) and normalize-space(substring-after(., $orcidSite)) = '')]" priority="2" />
+<!--  <xsl:template match="contrib-id[contains(.,$orcidSite)][normalize-space(substring-after(.,$orcidSite)) = '']" priority="2" />-->
 
   <xsl:template name="pub-date">
     <xsl:choose>

--- a/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
+++ b/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
@@ -311,8 +311,9 @@
         <xsl:apply-templates select="xref[(@ref-type='aff') or not(@ref-type)][string-length(@rid) > 0]" />
       </xsl:when>
       <!-- Affiliation is given at article level -->
-      <xsl:when test="not(xref[(@ref-type='aff') or not(@ref-type)]) and //article-meta/aff[not(@*)][position()=last()][string-length(text()) > 0]">
-        <xsl:apply-templates select="//article-meta/aff[not(@*)][position()=last()][string-length(text()) > 0]" />
+      <xsl:when test="not(xref[(@ref-type='aff') or not(@ref-type)])
+        and //article-meta/aff[not(@*)][position()=last()][string-length(text()[1]) > 0]">
+        <xsl:apply-templates select="//article-meta/aff[not(@*)][position()=last()][string-length(text()[1]) > 0]" />
       </xsl:when>
       <!-- Affiliation is given in aff ellement -->
       <xsl:otherwise>
@@ -364,11 +365,9 @@
   <!-- Reduce ORCID iDs given as complete URL -->
   <xsl:template match="contrib-id[contains(.,$orcidSite)]" priority="1">
     <xsl:variable name="orcid" select="substring-after(.,$orcidSite)"/>
-      <xsl:if test="string-length($orcid)>0">
-        <mods:nameIdentifier type="orcid">
-          <xsl:value-of select="$orcid" />
-        </mods:nameIdentifier>
-      </xsl:if>
+    <mods:nameIdentifier type="orcid">
+      <xsl:value-of select="$orcid" />
+    </mods:nameIdentifier>
   </xsl:template>
 
   <!-- Ignore empty ORCIDs -->
@@ -490,9 +489,6 @@
         <xsl:when test="license-p/ext-link/@xlink:href">
           <xsl:value-of select="substring-after(license-p/ext-link/@xlink:href,'//')"/>
         </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="''"/>
-        </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="categoryID" select="$mir_licenses//category[url[contains(@xlink:href,$url)]]/@ID" />

--- a/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
+++ b/mir-module/src/main/resources/xsl/sword/jats2mods.xsl
@@ -352,7 +352,7 @@
 
   <xsl:template match="*" mode="copy-affiliation" />
 
-  <xsl:template match="contrib-id" priority="1">
+  <xsl:template match="contrib-id">
     <mods:nameIdentifier type="{@contrib-id-type}">
       <xsl:value-of select="." />
     </mods:nameIdentifier>


### PR DESCRIPTION
- update jats2mods.xsl to xslt 3
- use oa_nlz only as default
- fixed solr query for ISSN
- fixed empty contrib-id
- changed mods:dateIssued to w3cdtf
- improved license parsing

[Link to jira](https://mycore.atlassian.net/browse/MIR-1213).
