### PR TITLE
MCR-2685 allow also numbers, '-' and '_' in file names for MIR

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -27,6 +27,8 @@ MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xsl/mods2mods.xsl,xsl/mo
 # until we are ready to switch to Saxon by default: 
 MCR.LayoutService.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
 
+# MyCoRe default is \\A.+\\z
+MCR.FileUpload.FileNamePattern=\\A[a-zA-Z0-9_\\-\\.]*\\z
 
 ##############################################################################
 # Configure ACL Checking                                                     #


### PR DESCRIPTION
related to [MCR-2685](https://mycore.atlassian.net/browse/MCR-2685).


[MCR-2685]: https://mycore.atlassian.net/browse/MCR-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ