### PR TITLE
MCR-2909 replaced deprecated method calls

### DIFF
--- a/mir-module/src/main/java/org/mycore/mir/sword2/MIRDeepGreepIngester.java
+++ b/mir-module/src/main/java/org/mycore/mir/sword2/MIRDeepGreepIngester.java
@@ -42,8 +42,8 @@ public class MIRDeepGreepIngester extends MIRSwordIngesterBase {
 
     @Override
     public MCRObjectID ingestMetadata(Deposit deposit) throws SwordError, SwordServerException {
-        final MCRObjectID newObjectId = MCRObjectID
-            .getNextFreeId(MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods");
+        String baseId = MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods";
+        final MCRObjectID newObjectId = MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId(baseId);
         try {
             final Path dgZip = MCRSwordUtil
                 .createTempFileFromStream("dgZip", deposit.getInputStream(), deposit.getMd5());

--- a/mir-module/src/main/java/org/mycore/mir/sword2/MIRGoobiIngester.java
+++ b/mir-module/src/main/java/org/mycore/mir/sword2/MIRGoobiIngester.java
@@ -33,8 +33,8 @@ public class MIRGoobiIngester extends MIRSwordIngesterBase {
 
     @Override
     public MCRObjectID ingestMetadata(Deposit entry) throws SwordError, SwordServerException {
-        final MCRObjectID newObjectId = MCRObjectID
-            .getNextFreeId(MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods");
+        String baseId = MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods";
+        final MCRObjectID newObjectId = MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId(baseId);
         final Map<String, List<String>> dublinCoreMetadata = entry.getSwordEntry().getDublinCore();
 
         Document dcDocument = buildDCDocument(dublinCoreMetadata);

--- a/mir-module/src/main/java/org/mycore/mir/sword2/MIRMETSIngester.java
+++ b/mir-module/src/main/java/org/mycore/mir/sword2/MIRMETSIngester.java
@@ -67,8 +67,8 @@ public class MIRMETSIngester extends MIRSwordIngesterBase {
 
     @Override
     public MCRObjectID ingestMetadata(Deposit entry) throws SwordError, SwordServerException {
-        final MCRObjectID newObjectId = MCRObjectID
-            .getNextFreeId(MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods");
+        String baseId = MCRConfiguration2.getStringOrThrow("MIR.projectid.default") + "_mods";
+        final MCRObjectID newObjectId = MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId(baseId);
         Document convertedDocument;
 
         Path tempFile = null;


### PR DESCRIPTION
use MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId(...) in mir-module

[Link to jira](https://mycore.atlassian.net/browse/MCR-2909).
