### PR TITLE
MIR-1292 MIR-1293 Updated template datacite2mods.xsl to support ORCID ids given by url

### DIFF
--- a/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
+++ b/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
@@ -52,13 +52,20 @@
             <xsl:value-of select="normalize-space(substring-after(.,','))" />
         </mods:namePart>
     </xsl:template>
-    
+
     <xsl:template match="nameIdentifier[@nameIdentifierScheme='ORCID']">
         <mods:nameIdentifier type="orcid">
-            <xsl:value-of select="text()" />
+            <xsl:choose>
+                <xsl:when test="contains(text(), '://orcid.org/')">
+                    <xsl:value-of select="substring-after(text(), '://orcid.org/')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="text()" />
+                </xsl:otherwise>
+            </xsl:choose>
         </mods:nameIdentifier>
     </xsl:template>
-    
+
     <xsl:template match="affiliation">
         <mods:affiliation>
             <xsl:value-of select="text()" />

--- a/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
+++ b/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
@@ -42,7 +42,7 @@
             <mods:role>
                 <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
             </mods:role>
-            <xsl:apply-templates select="nameIdentifier[string-length(mcrxml:getMatchingString(text(), $orcidRegex)) = (19)]" />
+            <xsl:apply-templates select="nameIdentifier[@nameIdentifierScheme='ORCID']" />
             <xsl:apply-templates select="affiliation" />
         </mods:name>
     </xsl:template>

--- a/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
+++ b/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
@@ -58,9 +58,11 @@
 
     <xsl:template match="nameIdentifier">
         <xsl:variable name="orcid" select="mcrxml:getMatchingString(text(), $orcidRegex)"/>
-        <mods:nameIdentifier type="orcid">
-            <xsl:value-of select="$orcid"/>
-        </mods:nameIdentifier>
+        <xsl:if test="string-length($orcid) = 19">
+            <mods:nameIdentifier type="orcid">
+                <xsl:value-of select="$orcid"/>
+            </mods:nameIdentifier>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="affiliation">

--- a/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
+++ b/mir-module/src/main/resources/xsl/import/datacite2mods.xsl
@@ -7,10 +7,13 @@
     xmlns:mods="http://www.loc.gov/mods/v3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xalan="http://xml.apache.org/xalan"
-    exclude-result-prefixes="xsl xsi xalan">
-    
+    xmlns:mcrxml="xalan://org.mycore.common.xml.MCRXMLFunctions"
+    exclude-result-prefixes="mcrxml xsl xsi xalan">
+
     <xsl:output method="xml" encoding="UTF-8" indent="yes" xalan:indent-amount="2" />
-    
+
+    <xsl:variable name="orcidRegex" select="'[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9,X]'"/>
+
     <xsl:template match="resource">
         <mods:mods>
             <xsl:apply-templates select="titles/title" />
@@ -39,7 +42,7 @@
             <mods:role>
                 <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
             </mods:role>
-            <xsl:apply-templates select="nameIdentifier[@nameIdentifierScheme='ORCID']" />
+            <xsl:apply-templates select="nameIdentifier[string-length(mcrxml:getMatchingString(text(), $orcidRegex)) = (19)]" />
             <xsl:apply-templates select="affiliation" />
         </mods:name>
     </xsl:template>
@@ -53,16 +56,10 @@
         </mods:namePart>
     </xsl:template>
 
-    <xsl:template match="nameIdentifier[@nameIdentifierScheme='ORCID']">
+    <xsl:template match="nameIdentifier">
+        <xsl:variable name="orcid" select="mcrxml:getMatchingString(text(), $orcidRegex)"/>
         <mods:nameIdentifier type="orcid">
-            <xsl:choose>
-                <xsl:when test="contains(text(), '://orcid.org/')">
-                    <xsl:value-of select="substring-after(text(), '://orcid.org/')"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="text()" />
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:value-of select="$orcid"/>
         </mods:nameIdentifier>
     </xsl:template>
 

--- a/mir-module/src/main/resources/xsl/strip-namespaces.xsl
+++ b/mir-module/src/main/resources/xsl/strip-namespaces.xsl
@@ -1,19 +1,20 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:template match="*">
-  <xsl:element name="{local-name()}">
-    <xsl:apply-templates />
-  </xsl:element>
-</xsl:template>
+  <xsl:template match="*">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:element>
+  </xsl:template>
 
-<xsl:template match="@*">
-  <xsl:attribute name="{local-name()}">
-    <xsl:value-of select="." />
-  </xsl:attribute>
-</xsl:template>
+  <xsl:template match="@*">
+    <xsl:attribute name="{local-name()}">
+      <xsl:value-of select="."/>
+      <xsl:apply-templates select="@*"/>
+    </xsl:attribute>
+  </xsl:template>
 
-<xsl:template match="text()">
-  <xsl:value-of select="." />
-</xsl:template>
+  <xsl:template match="text()">
+    <xsl:value-of select="."/>
+  </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
[MIR-1292](https://mycore.atlassian.net/browse/MIR-1292) and [MIR-1293](https://mycore.atlassian.net/browse/MIR-1293).

requires https://github.com/MyCoRe-Org/mycore/pull/2105

[MIR-1292]: https://mycore.atlassian.net/browse/MIR-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MIR-1293]: https://mycore.atlassian.net/browse/MIR-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ