### PR TITLE
MIR-1429 enhance podcast RSS feed

### DIFF
--- a/mir-module/src/main/resources/xslt/mycoreobject-podcast.xsl
+++ b/mir-module/src/main/resources/xslt/mycoreobject-podcast.xsl
@@ -249,6 +249,11 @@
         <xsl:value-of select="concat('Document ', @ID, ' does not have a derivate of type content!')" />
       </xsl:comment>
     </xsl:if>
+    <xsl:if test="count(structure/derobjects/derobject[classification/@categid='thumbnail']) &gt; 1">
+      <xsl:comment>
+        <xsl:value-of select="concat('Document ', @ID, ' has too many thumbnails!')" />
+      </xsl:comment>
+    </xsl:if>
     <xsl:if test="count($mods/mods:abstract) != 1 and
       not(count($mods/mods:abstract) = 2 and $mods/mods:abstract[@altRepGroup]) and
       not($mods/mods:relatedItem[@type='host']/mods:part/@order = 0)">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1429).

This pull request includes several enhancements and fixes to the `mycoreobject-podcast.xsl` file. The changes focus on improving the handling of publication dates, adding new XML namespaces, and enhancing the templates for podcast elements.

Key changes include:

### Enhancements to Date Handling:
* Added a new function `pc:pubDate` to handle both `xs:date` and `xs:dateTime` types, ensuring proper date and time formatting.
* Updated the template to use the new `pc:pubDate` function for publication date handling, ensuring accurate date and time conversion. [[1]](diffhunk://#diff-576213095412dc0ea58fc444ebbbfdc517a32af2a37dfc7c382499da27fb2cbfL256-R273) [[2]](diffhunk://#diff-576213095412dc0ea58fc444ebbbfdc517a32af2a37dfc7c382499da27fb2cbfL319-R330)

### Namespace and Template Updates:
* Introduced a new XML namespace `pc` for the podcast-related XSLT functions.
* Enhanced the `mycoreobject` template to include a new `thumbnail` mode, improving the podcast metadata.

### Conditional Logic Improvements:
* Added conditional logic to handle the context URL for `mycoreobject` links, ensuring the correct URL is selected based on availability.
