### PR TITLE
MIR-1430 use %SAXON% and %XALAN% for simpler configuration

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -18,7 +18,7 @@ MCR.CLI.Classes.External=%MCR.CLI.Classes.External%,org.mycore.mir.migration.MIR
 MCR.CLI.Classes.External=%MCR.CLI.Classes.External%,org.mycore.mir.migration.MIRMigration202206Utils
 
 MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xsl/mods2mods.xsl,xsl/mods2dc.xsl
-MCR.ContentTransformer.mycoreobject-compress.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.mycoreobject-compress.TransformerFactoryClass=%XALAN%
 
 
 MCR.User.PasswordCheck.Strategies.argon2.Class=org.mycore.user2.hash.bouncycastle.MCRArgon2Strategy
@@ -46,30 +46,30 @@ MCR.Layout.Transformer.Factory.XSLFolder=xsl
 
 #mir-module migration to Saxon
 MCR.URIResolver.xslIncludes.components=resource:xsl/mcr-module-startIview2.xsl,resource:xsl/sessionListing.xsl,resource:xsl/altoChanges.xsl
-MCR.ContentTransformer.mcr_error.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.mcr_error.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.mcr_error.Stylesheet=xsl/mcr_error.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
-MCR.ContentTransformer.MyCoReWebPage.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.MyCoReWebPage.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.MyCoReWebPage.Stylesheet=xsl/MyCoReWebPage.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
-MCR.ContentTransformer.site.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.site.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.site.Stylesheet=xsl/site.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
 
 #required for mycore-solr
 MCR.URIResolver.xslImports.solr-document=solr-basetemplate.xsl
 MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-document%,mycoreobject-dynamicfields.xsl
 MCR.URIResolver.xslIncludes.components=%MCR.URIResolver.xslIncludes.components%,resource:xsl/solr-layout-utils.xsl
-MCR.ContentTransformer.response.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.response.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.response.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xsl/response.xsl
 MCR.ContentTransformer.response-browse.Stylesheet=xsl/response-browse.xsl
 MCR.ContentTransformer.mycoreobject-solrdocument.Class=org.mycore.common.content.transformer.MCRXSL2JAXBTransformer
-MCR.ContentTransformer.mycoreobject-solrdocument.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.mycoreobject-solrdocument.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.mycoreobject-solrdocument.Stylesheet=xsl/mycoreobject-solrdocument.xsl
 MCR.ContentTransformer.mycoreobject-solrdocument.Context=org.mycore.solr.index.document.jaxb
 MCR.ContentTransformer.response-solrdocument.Class=org.mycore.common.content.transformer.MCRXSL2JAXBTransformer
-MCR.ContentTransformer.response-solrdocument.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.response-solrdocument.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.response-solrdocument.Stylesheet=xsl/response2batch.xsl,%MCR.ContentTransformer.mycoreobject-solrdocument.Stylesheet%
 MCR.ContentTransformer.response-solrdocument.Context=%MCR.ContentTransformer.mycoreobject-solrdocument.Context%
 MCR.ContentTransformer.response-prepared.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.response-prepared.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.ContentTransformer.response-prepared.TransformerFactoryClass=%XALAN%
 MCR.ContentTransformer.response-prepared.Stylesheet=xsl/response-join-results.xsl,xsl/response-addDocId.xsl,xsl/response-addDerivates.xsl
 MCR.URIResolver.xslIncludes.xeditorTemplates=solr-xeditor-templates.xsl
 
@@ -100,7 +100,7 @@ MIR.AccessKey.JAXBContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactor
 # Configure  new fact based ACL Checking                                     #
 ##############################################################################
 
-MCR.ContentTransformer.rules-helper.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.rules-helper.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.rules-helper.Stylesheet=xslt/rules-helper.xsl
 
 #MCR.Access.Strategy.Class=org.mycore.access.facts.MCRFactsAccessSystem
@@ -308,7 +308,7 @@ MCR.ContentTransformer.response-browse.Class=org.mycore.common.content.transform
 MCR.ContentTransformer.response-browse.Steps=response-mycoreobject,mycoreobject
 MCR.ContentTransformer.mods2xeditor.Stylesheet=xsl/editor/mods2xeditor.xsl
 MCR.ContentTransformer.mods2marcxml.Stylesheet=xslt/mods2marcxml.xsl,xslt/marc-tidy.xsl
-MCR.ContentTransformer.mods2marcxml.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.mods2marcxml.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.marcxml.Class=org.mycore.common.content.transformer.MCRTransformerPipe
 MCR.ContentTransformer.marcxml.Steps=mods,mods2marcxml
 MCR.ContentTransformer.oai-marcxml.Class=org.mycore.common.content.transformer.MCRTransformerPipe
@@ -318,9 +318,9 @@ MCR.ContentTransformer.oai-epicur.Stylesheet=xsl/mods2epicur.xsl
 MCR.ContentTransformer.oai-xMetaDissPlus.Stylesheet=xsl/mods2xMetaDissPlus.xsl
 MCR.ContentTransformer.oai-oai_dc.Stylesheet=xsl/mods2oai_dc.xsl
 MCR.ContentTransformer.datacite.Stylesheet=xslt/mycoreobject-datacite-mir.xsl
-MCR.ContentTransformer.datacite.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.datacite.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.oai-oai_datacite.Stylesheet=xslt/mods2datacite.xsl
-MCR.ContentTransformer.oai-oai_datacite.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.oai-oai_datacite.TransformerFactoryClass=%SAXON%
 MCR.URIResolver.xslIncludes.datacite=mycoreobject-datacite-mir.xsl
 
 MCR.ContentTransformer.response-subselect.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xsl/response.xsl,xsl/relatedItem-subselect.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
@@ -330,7 +330,7 @@ MCR.Viewer.metadata.transformer = mycoreobject-viewer
 MCR.ContentTransformer.mycoreobject-viewer.Stylesheet=xsl/mycoreobject-mods.xsl,xsl/mods-pure-viewer.xsl
 
 MCR.ContentTransformer.pica2mods.Stylesheet=xsl/pica2mods.xsl
-MCR.ContentTransformer.pica2mods.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.pica2mods.TransformerFactoryClass=%SAXON%
 
 # Configure stylesheets used by content transformers
 MIR.dc.diniPublType.classificationId=diniPublType2022
@@ -343,7 +343,7 @@ MIR.xMetaDissPlus.person.termsOfAddress2academicTitle=false
 # Support for Podcasts                                                       #
 ##############################################################################
 MCR.ContentTransformer.mycoreobject-podcast.Stylesheet=xslt/mycoreobject-podcast.xsl
-MCR.ContentTransformer.mycoreobject-podcast.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.mycoreobject-podcast.TransformerFactoryClass=%SAXON%
 # Apple requires an image of 3000x3000
 MCR.IIIFImage.thumbnail.MaxImageBytes=27000000
 
@@ -533,7 +533,7 @@ MCR.GoogleSitemap.SolrQuery=worldReadable:true AND ((objectType:mods AND -state:
 
 # MCR.ContentTransformer.ojsmets2mods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 # MCR.ContentTransformer.ojsmets2mods.Stylesheet=xslt/sword/ojsmets2mods.xsl
-# MCR.ContentTransformer.ojsmets2mods.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+# MCR.ContentTransformer.ojsmets2mods.TransformerFactoryClass=%SAXON%
 
 # Goobi
 # MCR.Sword.Collection.MyWorkspace.DefaultGoobi = org.mycore.mir.sword2.MIRGoobiCollectionProvider
@@ -549,7 +549,7 @@ MCR.GoogleSitemap.SolrQuery=worldReadable:true AND ((objectType:mods AND -state:
 # MCR.Sword.DefaultDeepGreen.Transformer=deepgreenjats2mods
 # MCR.Sword.DefaultDeepGreen.State=imported
 
-# MCR.ContentTransformer.deepgreenjats2mods.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+# MCR.ContentTransformer.deepgreenjats2mods.TransformerFactoryClass=%SAXON%
 # MCR.ContentTransformer.deepgreenjats2mods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 # MCR.ContentTransformer.deepgreenjats2mods.Stylesheet=xslt/sword/jats2mods.xsl
 
@@ -566,7 +566,7 @@ MCR.GoogleSitemap.SolrQuery=worldReadable:true AND ((objectType:mods AND -state:
 # MCR.ContentTransformer.dissemin2mods.Class=org.mycore.mir.sword2.MIRDisseminCollectionProvider
 # MCR.ContentTransformer.dissemin2mods.Stylesheet=xsl/sword/dissemin-mods2mycore-mods.xsl
 
-# MCR.ContentTransformer.mycoreobject2dissemin-status.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+# MCR.ContentTransformer.mycoreobject2dissemin-status.TransformerFactoryClass=%SAXON%
 # MCR.ContentTransformer.mycoreobject2dissemin-status.Stylesheet=xslt/sword/mycoreobject2dissemin-status.xsl
 
 
@@ -696,7 +696,7 @@ MCR.MODS.EnrichmentResolver.DataSource.JOP.issn.URI=xslStyle:import/jop2mods:htt
 MIR.OADOI.Mail.Address=%MCR.mir-module.MailSender%
 MCR.MODS.EnrichmentResolver.DataSource.OADOI.IdentifierTypes=doi
 MCR.MODS.EnrichmentResolver.DataSource.OADOI.doi.URI=xslStyle:import/simplify-json-xml,import/oadoi2mods:xslTransform:json2xml:https://api.oadoi.org/v2/{1}?email=%MIR.OADOI.Mail.Address%
-MCR.ContentTransformer.dummy-json2xml.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.dummy-json2xml.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.dummy-json2xml.Stylesheet=xslt/convertjson.xsl
 MCR.ContentTransformer.json2xml.Class=org.mycore.mir.importer.JSON2XMLTransformer
 
@@ -759,7 +759,7 @@ MIR.Workflow.PDFValidation=false
 ##############################################################################
 MCR.ContentTransformer.DefaultStep.Stylesheet=%MCR.LayoutTransformerFactory.Default.Stylesheets%
 MCR.ContentTransformer.newMetadataStylesheet.Stylesheet=xslt/metadata/mods-metadata-page.xsl
-MCR.ContentTransformer.newMetadataStylesheet.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+MCR.ContentTransformer.newMetadataStylesheet.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.mycoreobject.Class=org.mycore.common.content.transformer.MCRTransformerPipe
 MCR.ContentTransformer.mycoreobject.Steps=mycoreobject-modsmeta,newMetadataStylesheet,DefaultStep
 

--- a/mir-wizard/src/main/resources/config/mir-wizard/mycore.properties
+++ b/mir-wizard/src/main/resources/config/mir-wizard/mycore.properties
@@ -9,4 +9,4 @@ MIR.Wizard.LayoutStylesheet=xsl/mir-wizard-layout.xsl
 ######################################################################
 
 MCR.Startup.Class=org.mycore.mir.wizard.MIRWizardStartupHandler,%MCR.Startup.Class%
-MCR.LayoutService.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
+MCR.LayoutService.TransformerFactoryClass=%XALAN%


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1430).

This pull request includes several changes to the `mir-module/src/main/resources/config/mir/mycore.properties` file, primarily focusing on the replacement of specific TransformerFactoryClass implementations with placeholders. These changes aim to improve configurability and maintainability.

Replacement of TransformerFactoryClass implementations:

* Replaced `org.apache.xalan.processor.TransformerFactoryImpl` with `%XALAN%` for multiple content transformers. [[1]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L21-R21) [[2]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L49-R72)
* Replaced `net.sf.saxon.TransformerFactoryImpl` with `%SAXON%` for various content transformers. [[1]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L103-R103) [[2]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L311-R311) [[3]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L321-R323) [[4]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L346-R346) [[5]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L536-R536) [[6]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L552-R552) [[7]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L569-R569) [[8]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L699-R699) [[9]](diffhunk://#diff-3192279bae14a2ab86afc48d0b5b33fa96f3a7ea0ea51f2e526e61f67f3f78f6L762-R762)

Additionally, a similar change was made in the `mir-wizard/src/main/resources/config/mir-wizard/mycore.properties` file:

* Replaced `org.apache.xalan.processor.TransformerFactoryImpl` with `%XALAN%` for the layout service transformer factory class.