### PR TITLE
Update CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,31 +3,36 @@ name: test
 on: [ push, pull_request ]
 
 env:
-  MAVEN_OPTS: -Xmx1024M -Xss128M
-  GECKODRIVER_VERSION: 0.34.0
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
   BIBUTILS_VERSION: 7.2
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: temurin
         cache: maven
 
-    - name: Setup Gecko driver
-      uses: browser-actions/setup-geckodriver@latest
-      with:
-        geckodriver-version: ${{ env.GECKODRIVER_VERSION }}
+    - name: Set up Browser
+      run: |
+        # Geckodriver
+        echo ${GECKOWEBDRIVER} >> $GITHUB_PATH
+
+        # Chromedriver
+        echo ${CHROMEWEBDRIVER} >> $GITHUB_PATH
+
+        firefox --version
+        ${GECKOWEBDRIVER}/geckodriver --version
 
     - name: Fetch Bibutils cache
       id: bibutils-cache
@@ -46,45 +51,14 @@ jobs:
         ./configure
         make -j2
 
-    - name: Setup firefox
-      id: setup-firefox
-      uses: browser-actions/setup-firefox@v1
-      with:
-        firefox-version: latest-esr
-
-    - name: Setup Chrome
-      id: setup-chrome
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-
-    - name: Setup Chromedriver
-      uses: nanasess/setup-chromedriver@v2
-      with:
-        chromedriver-version: ${{ steps.setup-chrome.outputs.chrome-version }}
-
-    - name: Set up test dependencies
-      run: |
-        sudo apt install dbus-x11
-
-        # Selenium wants to run non-ESR FF
-        sudo ln -sfn ${{ steps.setup-firefox.outputs.firefox-path }} /usr/bin/firefox
-        sudo ln -sfn ${{ steps.setup-firefox.outputs.firefox-path }} /usr/bin/firefox-esr
-        firefox --version
-
-        geckodriver --version
-
-        echo "${HOME}/bibutils/bin" >> $GITHUB_PATH
-
     - name: Set current date as env variable
       run: echo "BUILD_START=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Build
       run: |
-        export $(dbus-launch)
-        mkdir ~/tmp
-        export TMPDIR=~/tmp
-        export FIREFOX_BIN=$(which firefox-esr)
+        mkdir ${{ runner.temp }}/${{ github.run_id }}.tmp
+        export TMPDIR=${{ runner.temp }}/${{ github.run_id }}.tmp
+        export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 
         mvn -B -P!standard-with-extra-repos -U -Djetty -e clean install
@@ -116,8 +90,3 @@ jobs:
           ./**/*error*.log
           ./**/*test.log
           ~/.m2/repository/solr-*/server/logs/*.log
-
-    - name: Save Maven cache
-      uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on: [ push, pull_request ]
 
 env:
   MAVEN_OPTS: -Xmx1024M -Xss128M
-  GECKODRIVER_VERSION: 0.27.0
-  BIBUTILS_VERSION: 6.10
+  GECKODRIVER_VERSION: 0.34.0
+  BIBUTILS_VERSION: 7.2
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout
@@ -22,20 +22,12 @@ jobs:
       with:
         java-version: 17
         distribution: temurin
+        cache: maven
 
-    - name: Fetch Geckodriver cache
-      id: geckodriver-cache
-      uses: actions/cache@v4
+    - name: Setup Gecko driver
+      uses: browser-actions/setup-geckodriver@latest
       with:
-        path: ~/geckodriver
-        key: ${{ env.GECKODRIVER_VERSION }}
-
-    - name: Fetch Geckodriver
-      if: steps.geckodriver-cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/geckodriver
-        curl -L https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz | \
-          tar -C ~/geckodriver/ -xzvf-
+        geckodriver-version: ${{ env.GECKODRIVER_VERSION }}
 
     - name: Fetch Bibutils cache
       id: bibutils-cache
@@ -54,31 +46,35 @@ jobs:
         ./configure
         make -j2
 
+    - name: Setup firefox
+      id: setup-firefox
+      uses: browser-actions/setup-firefox@v1
+      with:
+        firefox-version: latest-esr
+
+    - name: Setup Chrome
+      id: setup-chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: stable
+
+    - name: Setup Chromedriver
+      uses: nanasess/setup-chromedriver@v2
+      with:
+        chromedriver-version: ${{ steps.setup-chrome.outputs.chrome-version }}
+
     - name: Set up test dependencies
       run: |
-        # PPA by Mozilla for ESR releases
-        # replace 'sudo add-apt-repository ppa:mozillateam/ppa' with simple commands as workaround for https://github.com/orgs/community/discussions/69720
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21
-        sudo add-apt-repository "deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/ focal main"
-
-        sudo apt update
-        sudo apt install firefox-esr chromium-browser chromium-chromedriver dbus-x11
+        sudo apt install dbus-x11
 
         # Selenium wants to run non-ESR FF
-        sudo rm -rf /usr/lib/firefox/
-        sudo ln -s firefox-esr /usr/lib/firefox
-        sudo ln -s firefox-esr /usr/lib/firefox/firefox
+        sudo ln -sfn ${{ steps.setup-firefox.outputs.firefox-path }} /usr/bin/firefox
+        sudo ln -sfn ${{ steps.setup-firefox.outputs.firefox-path }} /usr/bin/firefox-esr
         firefox --version
 
-        ~/geckodriver/geckodriver --version
-        echo "${HOME}/geckodriver" >> $GITHUB_PATH
+        geckodriver --version
 
         echo "${HOME}/bibutils/bin" >> $GITHUB_PATH
-
-    - name: Restore Maven cache
-      uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: restore
 
     - name: Set current date as env variable
       run: echo "BUILD_START=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
@@ -91,8 +87,8 @@ jobs:
         export FIREFOX_BIN=$(which firefox-esr)
         export SELENIUM_BROWSER=firefox
 
-        mvn -B -P!standard-with-extra-repos -U -Djetty clean install
-        mvn -P!standard-with-extra-repos -B javadoc:javadoc
+        mvn -B -P!standard-with-extra-repos -U -Djetty -e clean install
+        mvn -P!standard-with-extra-repos -B javadoc:javadoc javadoc:test-javadoc -T1C
     - name: Login to Docker Hub
       if: contains('refs/heads/2022.06.x refs/heads/2023.06.x refs/heads/main', github.ref) && github.event_name=='push' && success()
       uses: docker/login-action@v2
@@ -119,6 +115,7 @@ jobs:
           ./**/screenshots
           ./**/*error*.log
           ./**/*test.log
+          ~/.m2/repository/solr-*/server/logs/*.log
 
     - name: Save Maven cache
       uses: skjolber/maven-cache-github-action@v1


### PR DESCRIPTION
fixes:
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
