### PR TITLE
MIR-1465 mir docker dev environment does not start on linux with rootless setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - XMX=${MIR_XMX}
       - XMS=${MIR_XMS}
       - MIR_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8295
-      - FIX_FILE_SYSTEM_RIGHTS=false
+      - FIX_FILE_SYSTEM_RIGHTS=true
     volumes:
       - ${MIR_HOME}:/mcr/home/
       - ${MIR_DATA}:/mcr/data/


### PR DESCRIPTION

[Link to jira](https://mycore.atlassian.net/browse/MIR-1465).
