### PR TITLE
MIR-1576 fix pagination in derivate file list subdirectories

### DIFF
--- a/mir-module/src/main/resources/META-INF/resources/js/mir/derivate-fileList.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/mir/derivate-fileList.js
@@ -562,7 +562,7 @@
 				aclWriteDB = $(list).attr("data-writedb");
 				aclDeleteDB = $(list).attr("data-deletedb");
 				urn = $(list).attr("data-urn");
-				numPerPage = $(list).attr("data-numperpage") || 10;
+				numPerPage = parseInt($(list).attr("data-numperpage"), 10) || 10;
 
 				$(fileBox).on("click", ".derivate_folder > a", function(evt) {
 					evt.preventDefault();


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1576)

## Summary

Pagination in subdirectories of the derivate file list returned all remaining items instead of one page when navigating to page 2 or later.

## Root cause

`numPerPage = $(list).attr("data-numperpage") || 10` returns a String when the attribute is set (always, since MIR-1347).

In `buildPagination()`:

```js
var end = start + numPerPage;
```

Page >= 2: `start = 10` (Number from multiplication), `numPerPage = "10"` (String) → `end = "1010"` (String concat). Guard `(end > children.length) && (end = children.length)` then collapses `end` to `children.length`, so the slice returns all remaining items.

## Fix

```js
numPerPage = parseInt($(list).attr("data-numperpage"), 10) || 10;
```

## Test plan

- [ ] Open a derivate with a subdirectory containing > 20 files
- [ ] Set `MIR.FileBrowser.FilesPerPage=10`
- [ ] Navigate into the subdirectory, click pagination page 2 → only items 11–20 visible
- [ ] Click last / first / next / previous → correct slice each time
- [ ] Root listing pagination still works