### PR TITLE
MIR-1578 fix non-ASCII characters in epicur identifier URLs

### DIFF
--- a/mir-module/src/main/resources/xsl/mods2epicur.xsl
+++ b/mir-module/src/main/resources/xsl/mods2epicur.xsl
@@ -77,14 +77,14 @@
       <xsl:when test="$filenumber = 0" />
       <xsl:when test="$filenumber = 1">
         <resource xmlns="urn:nbn:de:1111-2004033116">
-          <xsl:variable name="uri" select="mcr_directory/children//child[@type='file']/uri" />
-          <xsl:variable name="derId" select="substring-before(substring-after($uri,':/'), ':')" />
-          <xsl:variable name="filePath" select="substring-after(substring-after($uri, ':'), ':')" />
+          <xsl:variable name="ifsFileChild" select="mcr_directory/children//child[@type='file']" />
           <identifier scheme="url">
-            <xsl:value-of select="concat($ServletsBaseURL,'MCRFileNodeServlet/',$derId,$filePath)" />
+            <xsl:call-template name="buildURLOfFile">
+              <xsl:with-param name="ifsFileChild" select="$ifsFileChild" />
+            </xsl:call-template>
           </identifier>
           <format scheme="imt">
-            <xsl:value-of select="$uri/../contentType" />
+            <xsl:value-of select="$ifsFileChild/contentType" />
           </format>
         </resource>
       </xsl:when>
@@ -99,6 +99,18 @@
         </resource>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="buildURLOfFile">
+    <xsl:param name="ifsFileChild" />
+    <xsl:variable name="derId" select="substring-before(substring-after($ifsFileChild/uri,':/'), ':')" />
+    <xsl:variable name="filePath">
+      <xsl:for-each select="$ifsFileChild/ancestor::child[@type='directory']">
+        <xsl:value-of select="concat('/', name)" />
+      </xsl:for-each>
+      <xsl:value-of select="concat('/', $ifsFileChild/name)" />
+    </xsl:variable>
+    <xsl:value-of select="mcr:normalizeAbsoluteURL(concat($ServletsBaseURL,'MCRFileNodeServlet/',$derId,$filePath))" />
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1578)

## Summary

- Build the file path recursively from the raw `<name>` elements via `ancestor::child[@type='directory']` instead of using the IFS `<uri>` (which has mixed encoding: `%20` for spaces but raw non-ASCII characters).
- Normalize the resulting URL through `MCRXMLFunctions#normalizeAbsoluteURL` so the epicur output is guaranteed ASCII-only (RFC 3986).
- Reported by DNB: such URLs (e.g. with Arabic file names) crash their REST API and cannot be stored.

## Test plan

- [ ] Manually trigger OAI `metadataPrefix=epicur` for a record with non-ASCII characters in derivate file names and verify the `<identifier scheme="url">` value contains only ASCII / percent-encoded octets.
- [ ] Verify a record with a plain ASCII file name still produces an unchanged URL.
- [ ] Verify a record with a file inside a subdirectory produces the correct path.