### PR TITLE
MIR-1590 only remove preceding relatedItems when creating a new version

### DIFF
--- a/mir-module/src/main/resources/xsl/mods-addPreceding.xsl
+++ b/mir-module/src/main/resources/xsl/mods-addPreceding.xsl
@@ -17,8 +17,9 @@
     </mods:mods>
   </xsl:template>
 
-  <xsl:template match="mods:relatedItem">
-    <!-- remove all related item -->
+  <xsl:template match="mods:relatedItem[@type='preceding']">
+    <!-- remove existing preceding relations only; the previous version is added as the new
+         preceding object above. All other related items (host, series, ...) are kept (MIR-1590). -->
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1590).

When creating a new version of an entry (`editor/editor-admins.xed?oldVersion=<id>`), `mods-addPreceding.xsl` stripped **all** `mods:relatedItem` elements.

The intent of MIR-449 was to keep only a single `preceding` relation (pointing to the previous version) and avoid a chain of preceding objects. But removing every related item also dropped `host` (journal/parent), `series` and any other relation, detaching the new version from its context.

This restricts the removal to `preceding` only; the previous version is still added as the new `preceding` object, and all other related items are kept:

```xml
<xsl:template match="mods:relatedItem[@type='preceding']">
```