### PR TITLE
MIR-1592 URL-encode date/format params in callJava badge call

### DIFF
--- a/mir-module/src/main/resources/xsl/badges/mir-badges-date.xsl
+++ b/mir-module/src/main/resources/xsl/badges/mir-badges-date.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:mods="http://www.loc.gov/mods/v3"
-                exclude-result-prefixes="mods">
+                xmlns:mcrxsl="xalan://org.mycore.common.xml.MCRXMLFunctions"
+                exclude-result-prefixes="mods mcrxsl">
 
   <xsl:import href="xslImport:badges:badges/mir-badges-date.xsl"/>
   <xsl:include href="resource:xsl/badges/mir-badges-style-template.xsl"/>
@@ -29,7 +30,10 @@
         </xsl:call-template>
       </xsl:variable>
 
-      <xsl:variable name="label" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:formatISODate:', $date, ':', $format, ':', $CurrentLang))"/>
+      <!-- $date and $format may contain ':' (e.g. time pattern HH:mm:ss from metaData.dateTime),
+           which collides with the callJava argument separator; URL-encode them so MCRFunctionResolver
+           (URLDecoder.decode) restores the original values. On XSL3 migration replace with encode-for-uri(). -->
+      <xsl:variable name="label" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:formatISODate:', mcrxsl:encodeURL($date, 'UTF-8'), ':', mcrxsl:encodeURL($format, 'UTF-8'), ':', $CurrentLang))"/>
 
       <xsl:call-template name="output-badge">
         <xsl:with-param name="of-type" select="'hit_date'"/>
@@ -85,7 +89,10 @@
         </xsl:call-template>
       </xsl:variable>
 
-      <xsl:variable name="label" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:formatISODate:', $date, ':', $format, ':', $CurrentLang))"/>
+      <!-- $date and $format may contain ':' (e.g. time pattern HH:mm:ss from metaData.dateTime),
+           which collides with the callJava argument separator; URL-encode them so MCRFunctionResolver
+           (URLDecoder.decode) restores the original values. On XSL3 migration replace with encode-for-uri(). -->
+      <xsl:variable name="label" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:formatISODate:', mcrxsl:encodeURL($date, 'UTF-8'), ':', mcrxsl:encodeURL($format, 'UTF-8'), ':', $CurrentLang))"/>
 
       <xsl:call-template name="output-badge">
         <xsl:with-param name="of-type" select="'hit_date'"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1592)

## Problem

The date badge (`mir-badges-date.xsl`) builds a `callJava` resolver URI:

```
callJava:org.mycore.common.xml.MCRXMLFunctions:formatISODate:<date>:<format>:<CurrentLang>
```

`<format>` is taken from the i18n date patterns via `get-dateformat`. For dates that
fall back to `metaData.dateTime` the pattern contains colons (e.g. `dd.MM.yyyy - HH:mm:ss`,
`yyyy-MM-dd : hh:mm:ss`). `MCRFunctionResolver` splits the href on `:` (without limit) and
only `URLDecoder.decode`s the parts afterwards, so the colons in the pattern are treated as
argument separators. Instead of 3 params `(date, format, lang)` the resolver gets e.g.
`(date, "dd.MM.yyyy - HH", "mm", "ss", lang)`, selecting the wrong `formatISODate` overload →
wrong output or a `ParseException`. A `<date>` that is a full timestamp breaks the same way.

## Fix

URL-encode `$date` and `$format` with `mcrxsl:encodeURL(..., 'UTF-8')` before building the URI.
`encodeURL` wraps `URLEncoder.encode`, the matching counterpart to the resolver's
`URLDecoder.decode`, so the encoded `:` (`%3A`) survives the split and is restored.

Note: `encodeURIPath` is **not** usable here — it throws `URISyntaxException` / returns `null`
for patterns containing `:` and never percent-encodes `:` (valid pchar).

## Merge-up

- `2025.06.x` / `2025.12.x` carry a newer revision of this file → resolve on merge.
- `main` migrated the badges to XSL3 → replace `mcrxsl:encodeURL` with `encode-for-uri()`.

## Checklist

- [x] Code follows the project conventions
- [ ] Tested locally
- [ ] Documentation updated (n/a)
