### PR TITLE
MIR-1599 make submission workflow extensible via xslImport chain

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -712,7 +712,7 @@ MCR.Object.Static.Content.Generator.mir-history.Transformer=mir-history
 ##############################################################################
 # Workflow                                                                   #
 ##############################################################################
-MCR.URIResolver.xslImports.mirworkflow=metadata/mir-workflow.xsl
+MCR.URIResolver.xslImports.mirworkflow=metadata/mir-workflow-hook.xsl
 MIR.Workflow.Menu=false
 MIR.Workflow.Box=false
 MIR.Workflow.PDFValidation=false

--- a/mir-module/src/main/resources/xsl/metadata/mir-workflow-hook.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-workflow-hook.xsl
@@ -7,3 +7,4 @@
   <xsl:template match="mycoreobject" mode="editorReviewAdd"/>
 
 </xsl:stylesheet>
+

--- a/mir-module/src/main/resources/xsl/metadata/mir-workflow-hook.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-workflow-hook.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+  <xsl:import href="xslImport:mirworkflow:metadata/mir-workflow-hook.xsl"/>
+
+  <xsl:template match="mycoreobject" mode="creatorSubmittedAdd"/>
+  <xsl:template match="mycoreobject" mode="editorReviewAdd"/>
+
+</xsl:stylesheet>

--- a/mir-module/src/main/resources/xsl/metadata/mir-workflow.xsl
+++ b/mir-module/src/main/resources/xsl/metadata/mir-workflow.xsl
@@ -7,7 +7,7 @@
                 version="1.0" exclude-result-prefixes="i18n exslt mcrxml">
 
   <xsl:import href="xslImport:modsmeta:metadata/mir-workflow.xsl"/>
-  <xsl:import href="xslImport:mirworkflow:metadata/mir-workflow.xsl"/>
+  <xsl:import href="xslImport:mirworkflow"/>
   <xsl:import href="mir-pdf-errorbox.xsl"/>
   <xsl:param name="layout" select="'$'"/>
   <xsl:param name="MIR.Workflow.Box" select="'false'"/>
@@ -214,12 +214,6 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    <xsl:template match="mycoreobject" mode="creatorSubmittedAdd" priority="10">
-  </xsl:template>
-
-  <xsl:template match="mycoreobject" mode="editorReviewAdd" priority="10">
-  </xsl:template>
-
 
   <xsl:template name="buildLayout" priority="10">
     <xsl:param name="heading"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1599).

`mir-workflow.xsl` was both the workflow entry point (top of the `modsmeta` chain) and the only member of the `mirworkflow` import chain, importing that chain with its own self name. `xslImport:<name>:<self>` only resolves to entries *before* self, so stylesheets appended by overlays sit *after* it and are never imported — their template overrides never load. The empty `creatorSubmittedAdd`/`editorReviewAdd` defaults (`priority="10"`) in the entry point additionally blocked any override via import precedence.

## Changes
- Add `mir-workflow-hook.xsl` as the base of the `mirworkflow` chain, holding the empty default `creatorSubmittedAdd`/`editorReviewAdd` extension points (lowest precedence).
- Point `MCR.URIResolver.xslImports.mirworkflow` at the hook.
- `mir-workflow.xsl` now imports `xslImport:mirworkflow` (no self), becoming a pure consumer that pulls in the top of the chain.
- Remove the empty extension-point templates from `mir-workflow.xsl`.

Overlays can now append a stylesheet to `MCR.URIResolver.xslImports.mirworkflow` and override the extension points (the OPF plugin is the first consumer).

Verified with `mvn -pl mir-module -am clean install`: BUILD SUCCESS, 57 tests green.