### PR TITLE
MIR-1605 load pica2mods stylesheets from xslt/ folder

### DIFF
--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -303,7 +303,7 @@ MCR.ContentTransformer.oai-oai_openaire.Stylesheet=xslt/mycoreobject-openaire.xs
 MCR.ContentTransformer.response-subselect.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xslt/solr/response/response.xsl,xslt/relatedItem-subselect.xsl,%MCR.LayoutTransformerFactory.Default.Stylesheets%
 MCR.ContentTransformer.response-resultlist.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xslt/response-resultlist.xsl
 
-MCR.ContentTransformer.pica2mods.Stylesheet=xsl/pica2mods.xsl
+MCR.ContentTransformer.pica2mods.Stylesheet=xslt/pica2mods.xsl
 
 MCR.ContentTransformer.migrate-openaire.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.migrate-openaire.Stylesheet=xslt/migrate-openaire.xsl

--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
       <dependency>
         <groupId>org.mycore.pica2mods</groupId>
         <artifactId>pica2mods-xslt</artifactId>
-        <version>2.12</version>
+        <version>2.14-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.mycore</groupId>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1605).

The PPN import on the publish page failed with `FileNotFoundException: JAR entry not found` for `xsl/_common/_common/functions/detect-language.xsl` (duplicated `_common`).

Root cause: the pica2mods stylesheets use root-relative includes that only resolve when MyCoRe's include fallback searches the configured XSL folder (`MCR.Layout.Transformer.Factory.XSLFolder` = `xslt`), but the stylesheets shipped under `xsl/`. pica2mods now ships them under `xslt/` (MyCoRe-Org/pica2mods#138).

Changes here:
- bump `pica2mods-xslt` to `2.14-SNAPSHOT` (contains the `xslt/` layout)
- `MCR.ContentTransformer.pica2mods.Stylesheet` → `xslt/pica2mods.xsl`

Depends on a pica2mods release with the `xslt/` layout; the dependency version must be changed from `2.14-SNAPSHOT` to that release before merging.
