### PR TITLE
MIR-1615 Enable analysis-extras Solr module and add IT tests for text_ru_latin analyzer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - SOLR_SEARCH_PASSWORD=${SOLR_SEARCH_PASSWORD}
       - SOLR_INDEX_USER=${SOLR_INDEX_USER}
       - SOLR_INDEX_PASSWORD=${SOLR_INDEX_PASSWORD}
+      - SOLR_MODULES=analysis-extras
   tika:
     container_name: ${NAME}-tika
     image: apache/tika:2.9.2.1-full

--- a/mir-it/src/test/java/org/mycore/mir/it/tests/MIRRussianTransliterationITCase.java
+++ b/mir-it/src/test/java/org/mycore/mir/it/tests/MIRRussianTransliterationITCase.java
@@ -61,6 +61,51 @@ public class MIRRussianTransliterationITCase extends MIRITBase {
     }
 
     /**
+     * Tests that Russian stemming still works when searching with Latin transliteration.
+     * The document title contains the inflected Cyrillic word "библиотек". Searching for
+     * the transliterated nominative form "biblioteka" should only match when stemming is
+     * applied before transliteration.
+     */
+    @Test
+    public void testTitleSearchWithLatinCharactersAndRussianStemming() {
+        MIRSearchController searchController = new MIRSearchController(getDriver(), getAPPUrlString());
+        searchController.setTitle("biblioteka");
+
+        List<String> foundIds = collectResultIds();
+
+        Assert.assertTrue(
+            "Searching for 'biblioteka' (Latin nominative) should find Russian document " + RUSSIAN_DOC_ID
+                + " via Russian stemming before transliteration (found: " + String.join(",", foundIds) + ")",
+            foundIds.contains(RUSSIAN_DOC_ID));
+    }
+
+    /**
+     * Tests that Russian stopwords are removed before transliteration.
+     * The fixture contains the Russian stopword "и" as an individual token in the subject.
+     * Searching for its Latin transliteration "i" should not find the Russian document when
+     * stopword removal runs on Cyrillic tokens first.
+     */
+    @Test
+    public void testMetadataSearchWithLatinStopwordDoesNotMatch() {
+        MIRSearchController searchController = new MIRSearchController(getDriver(), getAPPUrlString());
+
+        List<MIRComplexSearchQuery> queries = List.of(
+            new MIRComplexSearchQuery(MIRSearchFieldCondition.enthält, "i",
+                MIRSearchField.Metadaten));
+
+        searchController.complexSearchBy(queries, null, null, null,
+            null, null, null, null, null);
+
+        List<String> foundIds = collectResultIds();
+
+        Assert.assertFalse(
+            "Searching for Russian stopword 'i' (Latin transliteration of 'и') should not find "
+                + RUSSIAN_DOC_ID + " when stopwords are removed before transliteration (found: "
+                + String.join(",", foundIds) + ")",
+            foundIds.contains(RUSSIAN_DOC_ID));
+    }
+
+    /**
      * Tests that a Russian abstract can be found using Latin transliteration.
      * The document abstract contains "Управление". The ICU Any-Latin transliteration
      * produces "upravlenie". Note: RussianLightStemFilterFactory only operates on Cyrillic,
@@ -87,7 +132,7 @@ public class MIRRussianTransliterationITCase extends MIRITBase {
     }
 
     private List<String> collectResultIds() {
-        return getDriver().waitAndFindElements(By.xpath(".//input[@name='id']"))
+        return getDriver().findElements(By.xpath(".//input[@name='id']"))
             .stream()
             .map(v -> Optional.ofNullable(v.getDomProperty("value"))
                 .orElseGet(() -> v.getDomAttribute("value")))

--- a/mir-it/src/test/resources/testFiles/mir_mods_00010006.xml
+++ b/mir-it/src/test/resources/testFiles/mir_mods_00010006.xml
@@ -12,7 +12,7 @@
           </mods:titleInfo>
           <mods:abstract xml:lang="ru">Управление научными публикациями требует новых цифровых инструментов</mods:abstract>
           <mods:subject xlink:type="simple">
-            <mods:topic xml:lang="ru">Библиотечные науки</mods:topic>
+            <mods:topic xml:lang="ru">Библиотечные науки и архивы</mods:topic>
           </mods:subject>
           <mods:name type="personal" xlink:type="simple">
             <mods:displayForm>Иванов, Алексей</mods:displayForm>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <solrVersionString>${solr-runner.solrVersionString}</solrVersionString>
             <cloudMode>true</cloudMode>
             <verbose>true</verbose>
-            <additionalParams>-Dsolr.config.lib.enabled=true</additionalParams>
+            <additionalParams>-Dsolr.modules=analysis-extras</additionalParams>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1615)

Related MyCoRe fix: [MCR-3737](https://mycore.atlassian.net/browse/MCR-3737)

**What kind of change does this PR introduce?**
Bugfix follow-up: enables the required Solr module and adds integration tests for the fixed `text_ru_latin` analyzer.

**Did you add tests for your changes?**
Yes — two new test methods in `MIRRussianTransliterationITCase`:
- `testTitleSearchWithLatinCharactersAndRussianStemming`: verifies Russian stemming works before transliteration.
- `testMetadataSearchWithLatinStopwordDoesNotMatch`: verifies Cyrillic stop words are removed before transliteration.

**Summary**
`ICUTransformFilterFactory` (used in the `text_ru_latin` Solr field type) requires the `analysis-extras` Solr module. This was not enabled in MIR, causing the module to fail to load. This PR enables it in both `docker-compose.yml` (runtime) and `pom.xml` (integration test runner).

The test fixture `mir_mods_00010006.xml` is extended to include the Russian stop word `и` as a standalone token, enabling the stop word test.

**Does this PR introduce a breaking change?**
No.

[MCR-3737]: https://mycore.atlassian.net/browse/MCR-3737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ