### PR TITLE
MIR-1615 Add IT tests verifying text_ru_latin analyzer filter order

### DIFF
--- a/mir-it/src/test/java/org/mycore/mir/it/tests/MIRRussianTransliterationITCase.java
+++ b/mir-it/src/test/java/org/mycore/mir/it/tests/MIRRussianTransliterationITCase.java
@@ -61,6 +61,51 @@ public class MIRRussianTransliterationITCase extends MIRITBase {
     }
 
     /**
+     * Tests that Russian stemming still works when searching with Latin transliteration.
+     * The document title contains the inflected Cyrillic word "библиотек". Searching for
+     * the transliterated nominative form "biblioteka" should only match when stemming is
+     * applied before transliteration.
+     */
+    @Test
+    public void testTitleSearchWithLatinCharactersAndRussianStemming() {
+        MIRSearchController searchController = new MIRSearchController(getDriver(), getAPPUrlString());
+        searchController.setTitle("biblioteka");
+
+        List<String> foundIds = collectResultIds();
+
+        Assert.assertTrue(
+            "Searching for 'biblioteka' (Latin nominative) should find Russian document " + RUSSIAN_DOC_ID
+                + " via Russian stemming before transliteration (found: " + String.join(",", foundIds) + ")",
+            foundIds.contains(RUSSIAN_DOC_ID));
+    }
+
+    /**
+     * Tests that Russian stopwords are removed before transliteration.
+     * The fixture contains the Russian stopword "и" as an individual token in the subject.
+     * Searching for its Latin transliteration "i" should not find the Russian document when
+     * stopword removal runs on Cyrillic tokens first.
+     */
+    @Test
+    public void testMetadataSearchWithLatinStopwordDoesNotMatch() {
+        MIRSearchController searchController = new MIRSearchController(getDriver(), getAPPUrlString());
+
+        List<MIRComplexSearchQuery> queries = List.of(
+            new MIRComplexSearchQuery(MIRSearchFieldCondition.enthält, "i",
+                MIRSearchField.Metadaten));
+
+        searchController.complexSearchBy(queries, null, null, null,
+            null, null, null, null, null);
+
+        List<String> foundIds = collectResultIds();
+
+        Assert.assertFalse(
+            "Searching for Russian stopword 'i' (Latin transliteration of 'и') should not find "
+                + RUSSIAN_DOC_ID + " when stopwords are removed before transliteration (found: "
+                + String.join(",", foundIds) + ")",
+            foundIds.contains(RUSSIAN_DOC_ID));
+    }
+
+    /**
      * Tests that a Russian abstract can be found using Latin transliteration.
      * The document abstract contains "Управление". The ICU Any-Latin transliteration
      * produces "upravlenie". Note: RussianLightStemFilterFactory only operates on Cyrillic,
@@ -87,7 +132,7 @@ public class MIRRussianTransliterationITCase extends MIRITBase {
     }
 
     private List<String> collectResultIds() {
-        return getDriver().waitAndFindElements(By.xpath(".//input[@name='id']"))
+        return getDriver().findElements(By.xpath(".//input[@name='id']"))
             .stream()
             .map(v -> Optional.ofNullable(v.getDomProperty("value"))
                 .orElseGet(() -> v.getDomAttribute("value")))

--- a/mir-it/src/test/resources/testFiles/mir_mods_00010006.xml
+++ b/mir-it/src/test/resources/testFiles/mir_mods_00010006.xml
@@ -12,7 +12,7 @@
           </mods:titleInfo>
           <mods:abstract xml:lang="ru">Управление научными публикациями требует новых цифровых инструментов</mods:abstract>
           <mods:subject xlink:type="simple">
-            <mods:topic xml:lang="ru">Библиотечные науки</mods:topic>
+            <mods:topic xml:lang="ru">Библиотечные науки и архивы</mods:topic>
           </mods:subject>
           <mods:name type="personal" xlink:type="simple">
             <mods:displayForm>Иванов, Алексей</mods:displayForm>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1615)

Related: [MCR-3737](https://mycore.atlassian.net/browse/MCR-3737), [MIR-1616](https://mycore.atlassian.net/browse/MIR-1616)

> **Relies on** MyCoRe-Org/mycore#3006 (MCR-3737) — the MyCoRe PR must be merged first for these tests to pass.

**What kind of change does this PR introduce?**
New integration tests verifying the correct behavior of the `text_ru_latin` Solr analyzer after the fix in MCR-3737.

**Did you add tests for your changes?**
Yes — two new test methods in `MIRRussianTransliterationITCase`:
- `testTitleSearchWithLatinCharactersAndRussianStemming`: searching for Latin `biblioteka` finds document with inflected Cyrillic `библиотек`, confirming stemming runs on Cyrillic before transliteration.
- `testMetadataSearchWithLatinStopwordDoesNotMatch`: searching for Latin `i` (transliteration of Russian stop word `и`) does not match a document containing `и` as isolated token, confirming stop word removal runs on Cyrillic before transliteration.

Test fixture `mir_mods_00010006.xml` extended to include `и` as standalone token in subject field.

**Does this PR introduce a breaking change?**
No.

[MCR-3737]: https://mycore.atlassian.net/browse/MCR-3737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MIR-1616]: https://mycore.atlassian.net/browse/MIR-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ