### PR TITLE
MIR-1616 Enable analysis-extras Solr module required for ICUTransformFilterFactory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - SOLR_SEARCH_PASSWORD=${SOLR_SEARCH_PASSWORD}
       - SOLR_INDEX_USER=${SOLR_INDEX_USER}
       - SOLR_INDEX_PASSWORD=${SOLR_INDEX_PASSWORD}
+      - SOLR_MODULES=analysis-extras
   tika:
     container_name: ${NAME}-tika
     image: apache/tika:2.9.2.1-full

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <solrVersionString>${solr-runner.solrVersionString}</solrVersionString>
             <cloudMode>true</cloudMode>
             <verbose>true</verbose>
-            <additionalParams>-Dsolr.config.lib.enabled=true</additionalParams>
+            <additionalParams>-Dsolr.modules=analysis-extras</additionalParams>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1616)

Related: [MCR-3737](https://mycore.atlassian.net/browse/MCR-3737)

> **Relies on** MyCoRe-Org/mycore#3006 (MCR-3737) — `ICUTransformFilterFactory` is introduced via that MyCoRe fix and requires the `analysis-extras` module to be enabled.

**What kind of change does this PR introduce?**
Bugfix: enables the Solr `analysis-extras` module which is required for `ICUTransformFilterFactory` used in the `text_ru_latin` field type.

**Did you add tests for your changes?**
Covered by MIR-1615.

**Summary**
Without `analysis-extras`, Solr cannot load `ICUTransformFilterFactory` and fails to initialize the schema. Two changes:
- `docker-compose.yml`: `SOLR_MODULES=analysis-extras` for the Solr service.
- `pom.xml`: `-Dsolr.modules=analysis-extras` for the Maven integration test runner (replaces `-Dsolr.config.lib.enabled=true`).

**Does this PR introduce a breaking change?**
No.

[MCR-3737]: https://mycore.atlassian.net/browse/MCR-3737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ