### PR TITLE
MIR-1593 Fix badge import errors

### DIFF
--- a/mir-module/src/main/resources/xslt/basket-objects.xsl
+++ b/mir-module/src/main/resources/xslt/basket-objects.xsl
@@ -6,6 +6,7 @@
   exclude-result-prefixes="#all">
 
   <xsl:import href="resource:xslt/orcid/mir-orcid.xsl" />
+  <xsl:import href="xslImport:badges" />
 
   <xsl:include href="resource:xslt/MyCoReLayout.xsl" />
   <xsl:include href="resource:xslt/csl-export-gui.xsl" />

--- a/mir-module/src/main/resources/xslt/basket-objects.xsl
+++ b/mir-module/src/main/resources/xslt/basket-objects.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="3.0"
   xmlns:mcri18n="http://www.mycore.de/xslt/i18n"
+  xmlns:mirorcidutil="http://www.mycore.de/xslt/mirorcidutil"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   exclude-result-prefixes="#all">
 
-  <xsl:import href="resource:xslt/orcid/mir-orcid.xsl" />
   <xsl:import href="xslImport:badges" />
 
   <xsl:include href="resource:xslt/MyCoReLayout.xsl" />
@@ -27,7 +27,7 @@
       <xsl:call-template name="export-csl" />
       <xsl:call-template name="basketEntries" />
     </div>
-    <xsl:if test="$isOrcidEnabled">
+    <xsl:if test="mirorcidutil:is-orcid-enabled()">
       <script type="module" src="{$WebApplicationBaseURL}js/mir/orcid-basket.js" />
     </xsl:if>
   </xsl:template>

--- a/mir-module/src/main/resources/xslt/modsdetails-external.xsl
+++ b/mir-module/src/main/resources/xslt/modsdetails-external.xsl
@@ -13,8 +13,6 @@
   exclude-result-prefixes="#all"
   extension-element-prefixes="datacite">
 
-  <xsl:import href="xslImport:badges" />
-
   <xsl:param name="MCR.Users.Superuser.UserName" />
   <xsl:param name="MIR.registerDOI" select="''" />
   <xsl:param name="MIR.registerURN" select="'true'" />


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1593).

The basket badges were imported in the wrong location. As a result, the following warnings appear in the log:

```
Stylesheet module ... mir-badges-date.xsl is included or imported more than once.
This is permitted, but may lead to errors or unexpected behavior.
```

In addition, mir-orcid.xsl has since been replaced by XSLT functions and is no longer required.