### PR TITLE
MIR-1613 Deny unprivileged access to blocked/deleted content

### DIFF
--- a/mir-cli/src/main/config/acl/defaultrules-commands.txt
+++ b/mir-cli/src/main/config/acl/defaultrules-commands.txt
@@ -11,6 +11,13 @@ update permission deletedb for id default_mods with rulefile ${app.home}/config/
 update permission addurn for id default_derivate with rulefile ${app.home}/config/acl/grant-editors.xml described by ${acl-description.editors}
 update permission read for id derivate:mir_access:intern with rulefile ${app.home}/config/acl/require-login.xml described by ${acl-description.require-login}
 update permission read for id derivate:mir_access:unlimited with rulefile ${app.home}/config/acl/grant-all.xml described by ${acl-description.require-login}
+update permission view for id derivate:mir_access:unlimited with rulefile ${app.home}/config/acl/grant-all.xml described by ${acl-description.all}
+
+# deny unprivileged access to the content of blocked or deleted objects (MIR-1613)
+update permission read for id derivate:state:blocked with rulefile ${app.home}/config/acl/grant-editors.xml described by ${acl-description.editors}
+update permission view for id derivate:state:blocked with rulefile ${app.home}/config/acl/grant-editors.xml described by ${acl-description.editors}
+update permission read for id derivate:state:deleted with rulefile ${app.home}/config/acl/grant-editors.xml described by ${acl-description.editors}
+update permission view for id derivate:state:deleted with rulefile ${app.home}/config/acl/grant-editors.xml described by ${acl-description.editors}
 
 update permission writedb for id mir_genres with rulefile ${app.home}/config/acl/grant-admin.xml described by ${acl-description.admins}
 update permission writedb for id mir_institutes with rulefile ${app.home}/config/acl/grant-admin.xml described by ${acl-description.admins}

--- a/mir-it/src/test/java/org/mycore/mir/it/tests/MIRBlockedContentITCase.java
+++ b/mir-it/src/test/java/org/mycore/mir/it/tests/MIRBlockedContentITCase.java
@@ -1,0 +1,175 @@
+package org.mycore.mir.it.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mycore.common.selenium.util.MCRBy;
+import org.mycore.mir.it.controller.MIRModsEditorController;
+import org.mycore.mir.it.controller.MIRPublishEditorController;
+import org.mycore.mir.it.controller.MIRUploadController;
+import org.mycore.mir.it.controller.MIRUserController;
+import org.mycore.mir.it.model.MIRAccess;
+import org.mycore.mir.it.model.MIRDNBClassification;
+import org.mycore.mir.it.model.MIRGenre;
+import org.mycore.mir.it.model.MIRLicense;
+import org.mycore.mir.it.model.MIRStatus;
+import org.mycore.mir.it.model.MIRTitleType;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Regression test for MIR-1613: the content (files) of a blocked or deleted object must not be
+ * accessible to unprivileged users.
+ * <p>
+ * Scenario: a submitter creates a document, uploads a file and submits it; an administrator publishes
+ * it and afterwards blocks it. A guest must then see the "blocked" message on the metadata page and
+ * must no longer be able to retrieve the uploaded file via the {@code MCRFileNodeServlet}.
+ */
+public class MIRBlockedContentITCase extends MIRITBase {
+
+    private static final String SUBMITTER_USER_NAME = "submitter";
+
+    private static final String SUBMITTER_USER_PASSWORD = "tugdriwsella";
+
+    private static final String BLOCKED_MESSAGE = "Das Dokument ist gesperrt!";
+
+    private MIRUploadController uploadController;
+
+    @Before
+    public final void init() {
+        String appURL = getAPPUrlString();
+        userController = new MIRUserController(getDriver(), appURL);
+        publishEditorController = new MIRPublishEditorController(getDriver(), appURL);
+        editorController = new MIRModsEditorController(getDriver(), appURL);
+        uploadController = new MIRUploadController(getDriver(), appURL);
+        userController.logoutIfLoggedIn();
+        userController.loginAs(MIRUserController.ADMIN_LOGIN, MIRUserController.ADMIN_PASSWD);
+        userController.createUser(SUBMITTER_USER_NAME, SUBMITTER_USER_PASSWORD, null, null, "submitter");
+        userController.logoutIfLoggedIn();
+    }
+
+    @Test
+    public void testBlockedDerivateFileForbiddenForGuest() throws IOException, InterruptedException {
+        // 1. a submitter creates a document, uploads a file and submits it
+        userController.loginAs(SUBMITTER_USER_NAME, SUBMITTER_USER_PASSWORD);
+        String fileName = createDocumentWithUploadedFile();
+        String receiveURL = driver.getCurrentUrl();
+        userController.logOff();
+
+        // 2. an administrator makes the content public and publishes the document
+        userController.loginAs(MIRUserController.ADMIN_LOGIN, MIRUserController.ADMIN_PASSWD);
+        publishAndMakePublicViaAdminEditor(receiveURL);
+
+        String fileURL = getFileNodeServletURL(receiveURL, fileName);
+
+        // sanity check: while published the file is publicly readable
+        Assert.assertEquals("Published file should be readable by a guest", 200, guestHttpStatus(fileURL));
+
+        // 3. the administrator blocks the document
+        setStatusViaAdminEditor(receiveURL, MIRStatus.gesperrt);
+
+        // 4a. the file must no longer be retrievable via the MCRFileNodeServlet for a guest
+        Assert.assertEquals("Blocked file must not be readable by a guest", 403, guestHttpStatus(fileURL));
+
+        // 4b. the metadata page must show the blocked message to a guest
+        userController.logOff();
+        driver.navigate().to(receiveURL);
+        driver.waitUntilPageIsLoaded(MIRTitleType.mainTitle.getValue());
+        Assert.assertNotNull("Blocked message should be present on the metadata page",
+            driver.waitAndFindElement(MCRBy.partialText(BLOCKED_MESSAGE)));
+    }
+
+    private String createDocumentWithUploadedFile() throws IOException, InterruptedException {
+        publishEditorController.open(() -> Assert.assertTrue(publishEditorController.isPublishOpened()));
+        publishEditorController.selectType(MIRGenre.article, null);
+        publishEditorController.submit();
+
+        driver.waitUntilPageIsLoaded("MODS-Dokument erstellen");
+        editorController.setTitle(MIRTestData.TITLE);
+        editorController.setClassifications(Stream.of(MIRDNBClassification._004).collect(Collectors.toList()));
+        // the mir_access (file access) select is only available in the admin editor, so the document
+        // is made public by the administrator later on; here we only set the required license
+        editorController.setAccessConditions(MIRLicense.cc_by_40);
+        editorController.save();
+        driver.waitAndFindElement(MCRBy.partialText(MIRTestData.SAVE_SUCCESS));
+
+        driver.waitAndFindElement(MCRBy.partialLinkText("Aktionen"),
+            ExpectedConditions::elementToBeClickable).click();
+        driver.waitAndFindElement(MCRBy.partialLinkText("Hinzufügen eines Dateibereichs"),
+            ExpectedConditions::elementToBeClickable).click();
+
+        File upload = uploadController.createTestFile();
+        uploadController.uploadFile(upload);
+
+        String fileName = upload.getName();
+        Assert.assertNotNull("Uploaded file should be present",
+            driver.waitAndFindElement(MCRBy.partialLinkText(fileName)));
+        return fileName;
+    }
+
+    private void publishAndMakePublicViaAdminEditor(String receiveURL) {
+        openAdminEditor(receiveURL);
+        editorController.setAccessConditions(MIRAccess.public_);
+        editorController.setStatus(MIRStatus.veröffentlicht);
+        editorController.save();
+        driver.waitAndFindElement(MCRBy.partialText(MIRTestData.SAVE_SUCCESS));
+    }
+
+    private void setStatusViaAdminEditor(String receiveURL, MIRStatus status) {
+        openAdminEditor(receiveURL);
+        editorController.setStatus(status);
+        editorController.save();
+        driver.waitAndFindElement(MCRBy.partialText(MIRTestData.SAVE_SUCCESS));
+    }
+
+    private void openAdminEditor(String receiveURL) {
+        driver.navigate().to(receiveURL);
+        driver.waitUntilPageIsLoaded(MIRTitleType.mainTitle.getValue());
+        // once a derivate exists there are several "Aktionen" dropdowns, so open the one whose menu
+        // actually contains the admin editor link; select via the "dropdown-toggle" class so the test
+        // works regardless of the Bootstrap version (data-toggle in BS4 vs. data-bs-toggle in BS5)
+        driver.waitAndFindElement(By.xpath(".//a[contains(@class, 'dropdown-toggle')]"
+            + "[following-sibling::ul[.//a[contains(normalize-space(.), 'Bearbeiten im Admin-Editor')]]]"),
+            ExpectedConditions::elementToBeClickable).click();
+        driver.waitAndFindElement(MCRBy.partialLinkText("Bearbeiten im Admin-Editor"),
+            ExpectedConditions::elementToBeClickable).click();
+    }
+
+    private String getFileNodeServletURL(String receiveURL, String fileName) {
+        driver.navigate().to(receiveURL);
+        driver.waitUntilPageIsLoaded(MIRTitleType.mainTitle.getValue());
+        WebElement fileBox = driver.waitAndFindElement(By.cssSelector("div.file_box_files"));
+        String derivateId = fileBox.getAttribute("data-deriid");
+        Assert.assertNotNull("Could not determine derivate id from metadata page", derivateId);
+        return getAPPUrlString() + "/servlets/MCRFileNodeServlet/" + derivateId + "/" + fileName;
+    }
+
+    private int guestHttpStatus(String url) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        userController.logoutIfLoggedIn();
+        userController.loginAs(MIRUserController.ADMIN_LOGIN, MIRUserController.ADMIN_PASSWD);
+        userController.deleteUser(SUBMITTER_USER_NAME);
+        userController.logoutIfLoggedIn();
+    }
+}

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -65,7 +65,10 @@ MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-docume
 ##############################################################################
 MCR.Access.Strategy.Class=org.mycore.mir.authorization.MIRStrategy
 # comma separated classification IDs that are relevant for ACL checks
-MIR.Access.Strategy.Classifications=mir_access
+# order matters: the first matching category wins, so "state" is checked before
+# "mir_access" to ensure blocked/deleted objects deny access even if their
+# mir_access category (e.g. unlimited) would otherwise grant it
+MIR.Access.Strategy.Classifications=state,mir_access
 MIR.Strategy.EditPIRoles=admin
 #MCR.Access.Strategy.CreatorAnyStatePermissions=read-history
 MCR.Access.Strategy.CreatorRole=submitter

--- a/mir-wizard/src/main/resources/setup/defaultrules-wizard-commands.xml
+++ b/mir-wizard/src/main/resources/setup/defaultrules-wizard-commands.xml
@@ -11,6 +11,13 @@
   <command file="resource:setup/acl/grant-all.xml" describedBy="always allowed">update permission view-derivate for id default_mods with rulefile {file} described by {describedBy}</command>
   <command file="resource:setup/acl/grant-editors.xml" describedBy="administrators and editors">update permission addurn for id default_derivate with rulefile {file} described by {describedBy}</command>
   <command file="resource:setup/acl/require-login.xml" describedBy="require login">update permission read for id derivate:mir_access:intern with rulefile {file} described by {describedBy}</command>
+  <command file="resource:setup/acl/grant-all.xml" describedBy="always allowed">update permission view for id derivate:mir_access:unlimited with rulefile {file} described by {describedBy}</command>
+
+  <!-- deny unprivileged access to the content of blocked or deleted objects (MIR-1613) -->
+  <command file="resource:setup/acl/grant-editors.xml" describedBy="administrators and editors">update permission read for id derivate:state:blocked with rulefile {file} described by {describedBy}</command>
+  <command file="resource:setup/acl/grant-editors.xml" describedBy="administrators and editors">update permission view for id derivate:state:blocked with rulefile {file} described by {describedBy}</command>
+  <command file="resource:setup/acl/grant-editors.xml" describedBy="administrators and editors">update permission read for id derivate:state:deleted with rulefile {file} described by {describedBy}</command>
+  <command file="resource:setup/acl/grant-editors.xml" describedBy="administrators and editors">update permission view for id derivate:state:deleted with rulefile {file} described by {describedBy}</command>
 
   <command file="resource:setup/acl/grant-admin.xml" describedBy="administrators only"> update permission writedb for id mir_genres with rulefile {file} described by {describedBy} </command>
   <command file="resource:setup/acl/grant-admin.xml" describedBy="administrators only"> update permission writedb for id mir_institutes with rulefile {file} described by {describedBy} </command>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1613)

## Problem

Files of objects in state `blocked` or `deleted` were still delivered to unprivileged users via the `MCRFileNodeServlet` (e.g. by clicking a thumbnail), even though the metadata page correctly shows the "blocked"/"deleted" message. The access strategy only consulted the `mir_access` classification and never the object state, so a blocked object in `mir_access:unlimited` stayed publicly readable.

## Fix

- Add `state` (before `mir_access`) to `MIR.Access.Strategy.Classifications` so the state category takes precedence over `mir_access:unlimited` (first matching category wins).
- Register default ACL rules in `mir-cli` and `mir-wizard`:
  - `derivate:state:blocked` / `derivate:state:deleted` — `read` + `view`, editors/admins only
  - `derivate:mir_access:unlimited` — `view` (grant all) as the counterpart so published content stays viewable

Both `read` (file delivery) and `view` (file box / `checkDerivateDisplayPermission`) are restricted, so blocked/deleted content is no longer reachable for guests.

> Note: existing installations do not re-run the default ACL setup. They need the rules added manually (advisory mail) or via a migration; this PR only fixes new installations and is meant to be merged up to the newer release lines.

## Test

`MIRBlockedContentITCase` reproduces the full lifecycle: a submitter creates a document and uploads a PDF, an admin publishes and then blocks it. It asserts that a guest then sees the blocked message and that the file is no longer reachable via the `MCRFileNodeServlet` (HTTP 403), while it was reachable (200) while published.

## Checklist

- [x] Integration tests pass (`MIR: Integration Tests ... SUCCESS`)
- [x] Code formatted (Eclipse formatter)