### PR TITLE
MIR-1623 Fix exception on metadata page when genre is missing

### DIFF
--- a/mir-module/src/main/resources/xslt/metadata/mir-breadcrumbs.xsl
+++ b/mir-module/src/main/resources/xslt/metadata/mir-breadcrumbs.xsl
@@ -21,14 +21,16 @@
     </xsl:variable>
     <div id="mir-breadcrumb">
       <ul class="breadcrumb">
-        <li class="breadcrumb-item">
-          <xsl:call-template name="categorySearchLink">
-            <xsl:with-param name="class" select="'navtrail'" />
-            <xsl:with-param name="node" select="$mods/mods:genre[@type='intern']"/>
-            <xsl:with-param name="parent" select="true()" />
-            <xsl:with-param name="owner"  select="$owner" />
-          </xsl:call-template>
-        </li>
+        <xsl:if test="$mods/mods:genre[@type='intern']">
+          <li class="breadcrumb-item">
+            <xsl:call-template name="categorySearchLink">
+              <xsl:with-param name="class" select="'navtrail'" />
+              <xsl:with-param name="node" select="$mods/mods:genre[@type='intern']"/>
+              <xsl:with-param name="parent" select="true()" />
+              <xsl:with-param name="owner"  select="$owner" />
+            </xsl:call-template>
+          </li>
+        </xsl:if>
         <li class="breadcrumb-item active">
           <xsl:variable name="completeTitle">
             <xsl:apply-templates select="$mods" mode="mods.title" />

--- a/mir-module/src/main/resources/xslt/metadata/mods-metadata.xsl
+++ b/mir-module/src/main/resources/xslt/metadata/mods-metadata.xsl
@@ -117,14 +117,16 @@
     <xsl:param name="owner" />
 
     <xsl:variable name="mycoreclass">
-      <xsl:choose>
-        <xsl:when test="$parent=true()">
-          <xsl:copy-of select="mcrmods:to-mycoreclass($node,'parent')" />
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:copy-of select="mcrmods:to-mycoreclass($node, 'single')" />
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:if test="$node">
+        <xsl:choose>
+          <xsl:when test="$parent=true()">
+            <xsl:copy-of select="mcrmods:to-mycoreclass($node,'parent')" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="mcrmods:to-mycoreclass($node, 'single')" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:if>
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="$mycoreclass/mycoreclass">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1623)

## Problem
Importing MODS without an intern genre caused an exception on the metadata page:

```
net.sf.saxon.trans.XPathException: An empty sequence is not allowed as the first argument of mcrmods:to-mycoreclass()
```

The breadcrumb template passes `mods:genre[@type='intern']` as `node` to `categorySearchLink`. With no genre this is an empty sequence, and `mcrmods:to-mycoreclass()` rejects an empty first argument.

## Fix
- `mods-metadata.xsl`: guard the `to-mycoreclass()` call with `<xsl:if test="$node">` so an empty node no longer throws.
- `mir-breadcrumbs.xsl`: only render the genre breadcrumb `<li>` when an intern genre exists, avoiding an empty item / leading separator.