### PR TITLE
MIR-1480 Replace confirm modal plugin for Bootstrap 5

### DIFF
--- a/mir-layout/src/main/resources/xsl/mir-cosmol-layout.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-cosmol-layout.xsl
@@ -122,12 +122,12 @@
           if (jQuery.fn.button){jQuery.fn.btn = jQuery.fn.button.noConflict();}
         </script>
         <script src="{$WebApplicationBaseURL}assets/bootstrap/js/bootstrap.bundle.min.js"></script>
-        <script src="{$WebApplicationBaseURL}assets/jquery/plugins/jquery-confirm/jquery.confirm.min.js"></script>
+        <script src="{$WebApplicationBaseURL}js/mir/confirm.js"></script>
         <script src="{$WebApplicationBaseURL}js/mir/base.min.js"></script>
         <script>
           $( document ).ready(function() {
             $('.overtext').tooltip();
-            $.confirm.options = {
+            MIRConfirm.options = {
               title: "<xsl:value-of select="i18n:translate('mir.confirm.title')" />",
               confirmButton: "<xsl:value-of select="i18n:translate('mir.confirm.confirmButton')" />",
               cancelButton: "<xsl:value-of select="i18n:translate('mir.confirm.cancelButton')" />",

--- a/mir-layout/src/main/resources/xsl/mir-flatmir-layout.xsl
+++ b/mir-layout/src/main/resources/xsl/mir-flatmir-layout.xsl
@@ -105,12 +105,12 @@
           if (jQuery.fn.button){jQuery.fn.btn = jQuery.fn.button.noConflict();}
         </script>
         <script src="{$WebApplicationBaseURL}assets/bootstrap/js/bootstrap.bundle.min.js"></script>
-        <script src="{$WebApplicationBaseURL}assets/jquery/plugins/jquery-confirm/jquery.confirm.min.js"></script>
+        <script src="{$WebApplicationBaseURL}js/mir/confirm.js"></script>
         <script src="{$WebApplicationBaseURL}js/mir/base.min.js"></script>
         <script>
           $( document ).ready(function() {
             $('.overtext').tooltip();
-            $.confirm.options = {
+            MIRConfirm.options = {
               title: "<xsl:value-of select="i18n:translate('mir.confirm.title')" />",
               confirmButton: "<xsl:value-of select="i18n:translate('mir.confirm.confirmButton')" />",
               cancelButton: "<xsl:value-of select="i18n:translate('mir.confirm.cancelButton')" />",

--- a/mir-module/GruntFile.js
+++ b/mir-module/GruntFile.js
@@ -29,7 +29,6 @@ module.exports = function(grunt) {
 
           'jquery' : 'jquery/dist',
 
-          'jquery/plugins/jquery-confirm' : 'myclabs.jquery.confirm/jquery.confirm.min.js',
           'jquery/plugins/jquery-placeholder' : 'jquery.placeholder/jquery.placeholder.min.js',
           'jquery/plugins/typeahead' : 'typeahead.js/dist/bloodhound.min.js',
           'jquery/plugins/bootstrap3-typeahead' : 'bootstrap-3-typeahead/bootstrap3-typeahead.min.js',

--- a/mir-module/package.json
+++ b/mir-module/package.json
@@ -25,7 +25,6 @@
         "jquery.dotdotdot": "1.7.4",
         "jquery.placeholder": "https://github.com/matoilic/jquery.placeholder.git",
         "moment": "2.29.4",
-        "myclabs.jquery.confirm": "2.7.0",
         "openlayers": "4.6.4",
         "popper.js": "^2.0.0-next.1",
         "select2": "^4.0.13",

--- a/mir-module/src/main/resources/META-INF/resources/js/mir/base.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/mir/base.js
@@ -477,7 +477,7 @@
     // editor fix (to many tables)
     $('table.editorPanel td:has(table)').css('padding', '0');
 
-    $('.confirm_deletion').confirm();
+    MIRConfirm.bind('.confirm_deletion');
 
     $(".searchfield_box form").submit(function() {
       $("input").each(function(i,elem) {

--- a/mir-module/src/main/resources/META-INF/resources/js/mir/confirm.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/mir/confirm.js
@@ -1,0 +1,216 @@
+/*!
+ * MIR Bootstrap 5 confirm dialog
+ */
+(function () {
+  "use strict";
+
+  const clickHandlers = new WeakMap();
+  const defaultOptions = {
+    text: "Are you sure?",
+    title: "",
+    confirmButton: "Yes",
+    cancelButton: "Cancel",
+    post: false,
+    submitForm: false,
+    confirmButtonClass: "btn-primary",
+    cancelButtonClass: "btn-secondary",
+    dialogClass: "modal-dialog",
+    modalOptionsBackdrop: true,
+    modalOptionsKeyboard: true
+  };
+  const dataOptionsMapping = {
+    "title": "title",
+    "text": "text",
+    "confirm-button": "confirmButton",
+    "submit-form": "submitForm",
+    "cancel-button": "cancelButton",
+    "confirm-button-class": "confirmButtonClass",
+    "cancel-button-class": "cancelButtonClass",
+    "dialog-class": "dialogClass",
+    "modal-options-backdrop": "modalOptionsBackdrop",
+    "modal-options-keyboard": "modalOptionsKeyboard"
+  };
+
+  function normalizeDataValue(value) {
+    if (value === "true") {
+      return true;
+    }
+    if (value === "false") {
+      return false;
+    }
+    return value;
+  }
+
+  function readDataOptions(element) {
+    const dataOptions = {};
+    if (!element) {
+      return dataOptions;
+    }
+    Object.entries(dataOptionsMapping).forEach(([attributeName, optionName]) => {
+      const value = element.getAttribute("data-" + attributeName);
+      if (value !== null) {
+        dataOptions[optionName] = normalizeDataValue(value);
+      }
+    });
+    return dataOptions;
+  }
+
+  function shouldSubmitForm(dataOptions, options) {
+    return dataOptions.submitForm
+      || (typeof dataOptions.submitForm === "undefined" && options.submitForm)
+      || (typeof dataOptions.submitForm === "undefined"
+        && typeof options.submitForm === "undefined"
+        && window.MIRConfirm.options.submitForm);
+  }
+
+  function confirmDefault(event, settings, dataOptions, options) {
+    if (shouldSubmitForm(dataOptions, options)) {
+      const form = options.button && options.button.closest("form");
+      if (form) {
+        form.submit();
+      }
+      return;
+    }
+
+    const url = event && (typeof event === "string"
+      ? event
+      : options.button && options.button.getAttribute("href"));
+    if (!url) {
+      return;
+    }
+    if (settings.post) {
+      const form = document.createElement("form");
+      form.method = "post";
+      form.action = url;
+      form.className = "d-none";
+      document.body.appendChild(form);
+      form.submit();
+    } else {
+      window.location = url;
+    }
+  }
+
+  function createElement(tagName, attributes, html) {
+    const element = document.createElement(tagName);
+    Object.entries(attributes || {}).forEach(([name, value]) => {
+      element.setAttribute(name, value);
+    });
+    if (typeof html !== "undefined") {
+      element.innerHTML = html;
+    }
+    return element;
+  }
+
+  function createModal(settings) {
+    const modal = createElement("div", {
+      class: "confirmation-modal modal fade",
+      tabindex: "-1",
+      role: "dialog"
+    });
+    const dialog = createElement("div", { class: settings.dialogClass });
+    const content = createElement("div", { class: "modal-content" });
+    const footer = createElement("div", { class: "modal-footer" });
+    const confirmButton = createElement("button", {
+      class: "confirm btn " + settings.confirmButtonClass,
+      type: "button",
+      "data-bs-dismiss": "modal"
+    }, settings.confirmButton);
+
+    modal.appendChild(dialog);
+    dialog.appendChild(content);
+
+    if (settings.title !== "") {
+      const header = createElement("div", { class: "modal-header" });
+      header.appendChild(createElement("h4", { class: "modal-title" }, settings.title));
+      header.appendChild(createElement("button", {
+        type: "button",
+        class: "btn-close",
+        "data-bs-dismiss": "modal",
+        "aria-label": "Close"
+      }));
+      content.appendChild(header);
+    }
+
+    content.appendChild(createElement("div", { class: "modal-body" }, settings.text));
+    footer.appendChild(confirmButton);
+
+    if (settings.cancelButton) {
+      footer.appendChild(createElement("button", {
+        class: "cancel btn " + settings.cancelButtonClass,
+        type: "button",
+        "data-bs-dismiss": "modal"
+      }, settings.cancelButton));
+    }
+
+    content.appendChild(footer);
+    return modal;
+  }
+
+  window.MIRConfirm = {
+    options: Object.assign({}, defaultOptions),
+
+    bind: function (selector, options) {
+      const elements = typeof selector === "string"
+        ? document.querySelectorAll(selector)
+        : selector;
+
+      Array.prototype.forEach.call(elements, (element) => {
+        const previousHandler = clickHandlers.get(element);
+        if (previousHandler) {
+          element.removeEventListener("click", previousHandler);
+        }
+
+        const handler = (event) => {
+          event.preventDefault();
+          window.MIRConfirm.show(Object.assign({ button: element }, options || {}), event);
+        };
+        clickHandlers.set(element, handler);
+        element.addEventListener("click", handler);
+      });
+    },
+
+    show: function (options, event) {
+      if (document.querySelector(".confirmation-modal")) {
+        return;
+      }
+      if (typeof bootstrap === "undefined" || typeof bootstrap.Modal === "undefined") {
+        console.error("Bootstrap Modal is not available.");
+        return;
+      }
+
+      const dataOptions = readDataOptions(options.button);
+      const settings = Object.assign({}, defaultOptions, window.MIRConfirm.options, {
+        confirm: function () {
+          confirmDefault(event, settings, dataOptions, options);
+        },
+        cancel: function () {},
+        button: null
+      }, options, dataOptions);
+      const modal = createModal(settings);
+      const modalInstance = new bootstrap.Modal(modal, {
+        backdrop: settings.modalOptionsBackdrop,
+        keyboard: settings.modalOptionsKeyboard
+      });
+
+      modal.addEventListener("shown.bs.modal", function () {
+        modal.querySelector(".confirm").focus();
+      });
+      modal.addEventListener("hidden.bs.modal", function () {
+        modalInstance.dispose();
+        modal.remove();
+      });
+      modal.querySelector(".confirm").addEventListener("click", function () {
+        settings.confirm(settings.button);
+      });
+      const cancelButton = modal.querySelector(".cancel");
+      if (cancelButton) {
+        cancelButton.addEventListener("click", function () {
+          settings.cancel(settings.button);
+        });
+      }
+
+      document.body.appendChild(modal);
+      modalInstance.show();
+    }
+  };
+})();

--- a/mir-module/src/main/resources/META-INF/resources/js/mir/derivate-fileList.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/mir/derivate-fileList.js
@@ -407,7 +407,7 @@
 			}
 			$(fileBox).append(fileList);
 			mycore.upload.enable($(fileBox)[0]);
-			$('.confirm_deletion').confirm();
+			MIRConfirm.bind('.confirm_deletion');
 			$('.rename').click(function (e) {
 				let href = $(this).attr("href");
 				let hrefURL = new URL(href);

--- a/mir-module/yarn.lock
+++ b/mir-module/yarn.lock
@@ -453,11 +453,6 @@ bootstrap-datepicker@1.9.0:
   dependencies:
     jquery ">=1.7.1 <4.0.0"
 
-bootstrap@3.*:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
-  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
-
 bootstrap@5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
@@ -1563,15 +1558,15 @@ jquery.dotdotdot@1.7.4:
   dependencies:
     jquery ">=1.7"
 
-jquery@>=1.6, "jquery@>=1.7.1 <4.0.0":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 jquery@>=1.7:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
+"jquery@>=1.7.1 <4.0.0":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-yaml@~3.14.0:
   version "3.14.1"
@@ -1960,14 +1955,6 @@ mux.js@6.0.1:
   dependencies:
     "@babel/runtime" "^7.11.2"
     global "^4.4.0"
-
-myclabs.jquery.confirm@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/myclabs.jquery.confirm/-/myclabs.jquery.confirm-2.7.0.tgz#f1830647caf990748b9924395e5895ccc6084e9c"
-  integrity sha1-8YMGR8r5kHSLmSQ5XliVzMYITpw=
-  dependencies:
-    bootstrap "3.*"
-    jquery ">=1.6"
 
 nanoid@^3.3.7:
   version "3.3.7"


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1480)

## Problem

The delete confirmation dialog was still provided by the old `myclabs.jquery.confirm` plugin. That plugin builds Bootstrap 3 modal markup, so with Bootstrap 5 the close icon is rendered incorrectly and the confirm/cancel buttons cannot be clicked reliably.

## Fix

- Replace the myclabs confirm plugin with a small native MIR confirm helper at `assets/mir/js/confirm.js`.
- Render Bootstrap 5 modal markup (`btn-close`, `data-bs-dismiss`) and use `bootstrap.Modal` directly.
- Keep the existing delete link behavior and data attributes for `confirm_deletion` links.
- Remove the obsolete `myclabs.jquery.confirm` dependency and its Bootstrap 3 transitive dependency.

## Test

- `node --check mir-module/src/main/resources/META-INF/resources/assets/mir/js/confirm.js`
- `node_modules/.bin/grunt uglify:mir --assetsDirectory=/home/paschty/workspace/mir/mir-module/target/classes/META-INF/resources/assets --moduleDirectory=/home/paschty/workspace/mir/mir-module`

Manual smoke test: delete confirmation modal for uploaded files opens and can be closed via cancel/close controls.
