### PR TITLE
MIR-1633 Fix basket on object page, search hit and basket display

### DIFF
--- a/mir-it/src/test/java/org/mycore/mir/it/controller/MIRBasketController.java
+++ b/mir-it/src/test/java/org/mycore/mir/it/controller/MIRBasketController.java
@@ -1,0 +1,133 @@
+package org.mycore.mir.it.controller;
+
+import java.util.List;
+
+import org.mycore.common.selenium.drivers.MCRWebdriverWrapper;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Drives the object basket UI: the add/remove button on an object page,
+ * the basket toggle on the search result page and the basket display page.
+ */
+public class MIRBasketController extends MIRTestController {
+
+    private static final String BASKET_TYPE = "objects";
+
+    /**
+     * Add/remove button on the object detail page. Selects only the toggle button (action=add or
+     * action=remove), so the navigation basket menu (action=show) is not matched.
+     */
+    private static final By OBJECT_PAGE_ADD = By.xpath(
+        "//a[contains(@href,'MCRBasketServlet') and contains(@href,'action=add')]");
+
+    private static final By OBJECT_PAGE_REMOVE = By.xpath(
+        "//a[contains(@href,'MCRBasketServlet') and contains(@href,'action=remove')]");
+
+    private static final By OBJECT_PAGE_TOGGLE = By.xpath(
+        "//a[contains(@href,'MCRBasketServlet') and (contains(@href,'action=add') or contains(@href,'action=remove'))]");
+
+    public MIRBasketController(MCRWebdriverWrapper driver, String baseURL) {
+        super(driver, baseURL);
+    }
+
+    public void openObjectPage(String objectId) {
+        driver.get(baseURL + "/receive/" + objectId);
+        // wait until the basket toggle is rendered, so the membership state is decided
+        driver.waitAndFindElement(OBJECT_PAGE_TOGGLE);
+    }
+
+    /**
+     * @return {@code true} if the object page shows the "remove from basket" button,
+     *         {@code false} if it shows the "add to basket" button.
+     */
+    public boolean isObjectInBasketAccordingToObjectPage() {
+        driver.waitAndFindElement(OBJECT_PAGE_TOGGLE);
+        return !driver.findElements(OBJECT_PAGE_REMOVE).isEmpty();
+    }
+
+    public void addToBasketViaObjectPage() {
+        driver.waitAndFindElement(OBJECT_PAGE_ADD).click();
+        // the add link redirects back to the object page, which then shows the remove button
+        driver.waitAndFindElement(OBJECT_PAGE_REMOVE);
+    }
+
+    public void addObjectToBasket(String objectId) {
+        openObjectPage(objectId);
+        addToBasketViaObjectPage();
+    }
+
+    public void openBasket() {
+        driver.get(baseURL + "/servlets/MCRBasketServlet?type=" + BASKET_TYPE + "&action=show");
+        driver.waitAndFindElement(By.id("basket"));
+    }
+
+    public void clearBasket() {
+        driver.get(baseURL + "/servlets/MCRBasketServlet?type=" + BASKET_TYPE + "&action=clear");
+    }
+
+    /**
+     * On the basket display page: the formatted title links of all entries. An empty list means the
+     * basket content was not rendered by the {@code basketContent} template (raw text fallback).
+     */
+    public List<WebElement> getBasketEntryTitleLinks() {
+        return driver.findElements(By.xpath("//h3[contains(@class,'hit_title')]//a[contains(@href,'/receive/')]"));
+    }
+
+    /**
+     * On the basket display page: the object IDs of all entries in their current display order.
+     */
+    public List<String> getBasketEntryOrder() {
+        return getBasketEntryTitleLinks().stream()
+            .map(link -> {
+                String href = link.getDomAttribute("href");
+                return href.substring(href.lastIndexOf("/receive/") + "/receive/".length());
+            })
+            .toList();
+    }
+
+    /**
+     * Clicks the "down" button of the given basket entry and waits for the basket to reload.
+     */
+    public void moveDown(String objectId) {
+        clickEntryActionAndReload("down", objectId);
+    }
+
+    /**
+     * Clicks the "up" button of the given basket entry and waits for the basket to reload.
+     */
+    public void moveUp(String objectId) {
+        clickEntryActionAndReload("up", objectId);
+    }
+
+    /**
+     * The up/down buttons are only links (with action and id) when the move is possible; a disabled
+     * button has {@code href="#"} and is therefore not matched here.
+     */
+    private void clickEntryActionAndReload(String action, String objectId) {
+        WebElement button = driver.waitAndFindElement(By.xpath(
+            "//a[contains(@href,'action=" + action + "') and contains(@href,'id=" + objectId + "')]"));
+        button.click();
+        driver.waitFor(ExpectedConditions.stalenessOf(button));
+        driver.waitAndFindElement(By.id("basket"));
+    }
+
+    public boolean isObjectRenderedInBasket(String objectId) {
+        return !driver.findElements(
+            By.xpath("//div[contains(@class,'hit_item')]//h3[contains(@class,'hit_title')]"
+                + "//a[contains(@href,'" + objectId + "')]"))
+            .isEmpty();
+    }
+
+    /**
+     * @return {@code true} if the search result hit for the given object shows the "remove from basket"
+     *         link, i.e. the search page recognizes the object as part of the basket.
+     */
+    public boolean isObjectInBasketAccordingToSearchHit(String objectId) {
+        driver.waitAndFindElement(By.xpath("//*[contains(@href,'" + objectId + "')]"));
+        return !driver.findElements(
+            By.xpath("//a[contains(@class,'remove_from_basket') and contains(@href,'" + objectId + "')]"))
+            .isEmpty();
+    }
+}

--- a/mir-it/src/test/java/org/mycore/mir/it/tests/MIRBasketITCase.java
+++ b/mir-it/src/test/java/org/mycore/mir/it/tests/MIRBasketITCase.java
@@ -1,0 +1,100 @@
+package org.mycore.mir.it.tests;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mycore.mir.it.controller.MIRBasketController;
+import org.mycore.mir.it.controller.MIRSearchController;
+import org.mycore.mir.it.controller.MIRUserController;
+import org.mycore.mir.it.model.MIRSearchTestDataLoader;
+
+/**
+ * Integration test for the object basket (see MIR-1633).
+ * <p>
+ * Verifies three regressions of the XSLT/Saxon migration:
+ * <ol>
+ *   <li>the object page reflects the real basket membership (add vs. remove button),</li>
+ *   <li>the basket display page renders the entries with the {@code basketContent} template instead of
+ *       dumping the raw object text,</li>
+ *   <li>the search result hit reflects the real basket membership (basket type {@code objects}).</li>
+ * </ol>
+ */
+public class MIRBasketITCase extends MIRITBase {
+
+    private static final String OBJECT_ID = "mir_mods_00010001";
+
+    private static final String OBJECT_ID_2 = "mir_mods_00010002";
+
+    private static final String OBJECT_TITLE = "Untersuchungen zur Entwicklung moderner Bibliotheken";
+
+    private MIRBasketController basketController;
+
+    @Before
+    public final void init() throws IOException, InterruptedException {
+        MIRSearchTestDataLoader searchTestDataLoader = new MIRSearchTestDataLoader();
+        searchTestDataLoader.lazyLoadData(getDriver());
+
+        String appURL = getAPPUrlString();
+        MIRUserController userController = new MIRUserController(getDriver(), appURL);
+        userController.logoutIfLoggedIn();
+        userController.loginAs(MIRUserController.ADMIN_LOGIN, MIRUserController.ADMIN_PASSWD);
+
+        this.basketController = new MIRBasketController(getDriver(), appURL);
+        // start from a known empty basket
+        this.basketController.clearBasket();
+    }
+
+    @Test
+    public void testBasket() {
+        // 1. object page: object is not in the basket -> "add" button must be shown
+        basketController.openObjectPage(OBJECT_ID);
+        Assert.assertFalse("Object page must show the add button when the object is not in the basket",
+            basketController.isObjectInBasketAccordingToObjectPage());
+
+        // 2. add the object -> object page must now show the "remove" button
+        basketController.addToBasketViaObjectPage();
+        Assert.assertTrue("Object page must show the remove button after the object was added to the basket",
+            basketController.isObjectInBasketAccordingToObjectPage());
+
+        // 3. basket display page must render the entry via the basketContent template, not as raw text
+        basketController.openBasket();
+        Assert.assertTrue("Basket must render the object with the formatted hit layout (a hit_title link), "
+            + "not as raw text", basketController.isObjectRenderedInBasket(OBJECT_ID));
+
+        // 4. search result hit must reflect the basket membership (basket type 'objects')
+        MIRSearchController searchController = new MIRSearchController(getDriver(), getAPPUrlString());
+        searchController.simpleSearchBy(OBJECT_TITLE, null, null, null, null);
+        Assert.assertTrue("Search result hit must show the remove-from-basket link for an object in the basket",
+            basketController.isObjectInBasketAccordingToSearchHit(OBJECT_ID));
+
+        // 5. remove again -> object page must show the "add" button
+        basketController.clearBasket();
+        basketController.openObjectPage(OBJECT_ID);
+        Assert.assertFalse("Object page must show the add button after the basket was cleared",
+            basketController.isObjectInBasketAccordingToObjectPage());
+    }
+
+    @Test
+    public void testBasketOrdering() {
+        // add two objects: the basket appends, so the initial order is [OBJECT_ID, OBJECT_ID_2]
+        basketController.addObjectToBasket(OBJECT_ID);
+        basketController.addObjectToBasket(OBJECT_ID_2);
+
+        basketController.openBasket();
+        Assert.assertEquals("Basket order after adding both objects",
+            List.of(OBJECT_ID, OBJECT_ID_2), basketController.getBasketEntryOrder());
+
+        // move the first entry down -> order must become [OBJECT_ID_2, OBJECT_ID]
+        basketController.moveDown(OBJECT_ID);
+        Assert.assertEquals("Basket order after moving the first entry down",
+            List.of(OBJECT_ID_2, OBJECT_ID), basketController.getBasketEntryOrder());
+
+        // move it up again -> order must be back to [OBJECT_ID, OBJECT_ID_2]
+        basketController.moveUp(OBJECT_ID);
+        Assert.assertEquals("Basket order after moving the entry up again",
+            List.of(OBJECT_ID, OBJECT_ID_2), basketController.getBasketEntryOrder());
+    }
+}

--- a/mir-module/src/main/resources/xslt/modsdetails-external.xsl
+++ b/mir-module/src/main/resources/xslt/modsdetails-external.xsl
@@ -234,7 +234,7 @@
     <xsl:variable name="basketType" select="'objects'" />
     <div class="btn-group d-flex">
       <xsl:choose>
-        <xsl:when test="document(concat('callJava:org.mycore.frontend.basket.MCRBasketManager:contains:',$basketType,':',/mycoreobject/@ID))">
+        <xsl:when test="exists(document(concat('basket:', $basketType, ':', /mycoreobject/@ID))/entry/@uri)">
           <a class="btn btn-primary btn-sm w-100"
              href="{$ServletsBaseURL}MCRBasketServlet?type={$basketType}&amp;action=remove&amp;redirect={encode-for-uri($RequestURL)}&amp;id={/mycoreobject/@ID}">
             <i class="fas fa-minus">
@@ -626,7 +626,7 @@
     </li>
   </xsl:template>
 
-  <xsl:template match="/mycoreobject[contains(@ID,'_mods_')]" mode="basketContent" priority="1">
+  <xsl:template match="mycoreobject[contains(@ID,'_mods_')]" mode="basketContent" priority="1">
     <xsl:variable name="objID" select="@ID" />
     <xsl:variable name="mods-type">
       <xsl:apply-templates select="." mode="mods-type" />

--- a/mir-module/src/main/resources/xslt/response-mir.xsl
+++ b/mir-module/src/main/resources/xslt/response-mir.xsl
@@ -1210,7 +1210,7 @@
     </xsl:variable>
 
     <xsl:choose>
-      <xsl:when test="exists(document(concat('basket:object:', $identifier))/entry/@uri)">
+      <xsl:when test="exists(document(concat('basket:objects:', $identifier))/entry/@uri)">
         <!-- remove from basket -->
         <a
           class="hit_option remove_from_basket {$dropdownclass}"


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1633).

The XSLT/Saxon migration broke three parts of the object basket:

- **Object page** (`modsdetails-external.xsl`): the membership check used a `callJava:` resolver whose result is always a non-empty node-set, so the `xsl:when` test was always true and the page always showed the "remove from basket" button. Now uses the `basket:` URI resolver and tests for the entry's `@uri`.
- **Search result hit** (`response-mir.xsl`): the check used basket type `object` (singular) while the servlet uses `objects` (plural). These are separate baskets, so it never matched. Fixed the type.
- **Basket display** (`modsdetails-external.xsl`): the `basketContent` template only matched the document root (`/mycoreobject`), but `action=show` embeds the object as a child of `<entry>`, so the entry was dumped as raw text. Now matches `mycoreobject` in any position. (The object-page fix resolves the entry content into the session via the `basket:` resolver, which is what triggers the embedded path.)

## Tests

Adds `MIRBasketITCase` (Selenium IT) covering:
- add/remove toggle on the object page,
- basket display rendering with the formatted hit layout (not raw text),
- search hit reflecting basket membership,
- entry reordering (up/down).

Full `mvn clean install` incl. integration tests passes locally; `MIRBasketITCase` runs 2 tests, 0 failures.