### PR TITLE
MIR-1637 use form-select for ORCID profile select dropdown arrow

### DIFF
--- a/mir-module/src/main/resources/xsl/orcid/mir-orcid-export-ui.xsl
+++ b/mir-module/src/main/resources/xsl/orcid/mir-orcid-export-ui.xsl
@@ -22,7 +22,7 @@
               <label for="orcidProfileSelect">
                 <xsl:value-of select="document('i18n:mir.orcid.publication.export.description')"/>
               </label>   
-              <select class="form-control mt-1" id="orcidProfileSelect">
+              <select class="form-select mt-1" id="orcidProfileSelect">
                 <option value="" selected="selected">
                   <xsl:value-of select="document('i18n:mir.select')"/>
                 </option>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1637).

## Summary

The export-to-ORCID modal profile select (`#orcidProfileSelect` in `mir-module/src/main/resources/xsl/orcid/mir-orcid-export-ui.xsl`) used `.form-control`. In Bootstrap 5 the select dropdown caret is provided by `.form-select`, not `.form-control`, so the arrow was missing.

Fix: use `.form-select`. This is a MIR-native file (added in MIR-1445), not a mycore fork, so it is fixed directly in MIR.

Tested locally: the profile select now renders the dropdown arrow (verified via the export-to-ORCID modal on a search result page; no linked ORCID account required, only `MCR.ORCID2.OAuth.ClientSecret` set).

Same Bootstrap 5 root cause as MIR-1635.
