### PR TITLE
MCR-3811 Create mycore-vue module with shared toolchain and MCRVueRootServlet

### DIFF
--- a/mir-module/src/main/resources/META-INF/web-fragment.xml
+++ b/mir-module/src/main/resources/META-INF/web-fragment.xml
@@ -114,7 +114,7 @@
 
   <servlet>
     <servlet-name>AccessKeyManager</servlet-name>
-    <servlet-class>org.mycore.webtools.vue.MCRVueRootServlet</servlet-class>
+    <servlet-class>org.mycore.frontend.vue.MCRVueRootServlet</servlet-class>
     <init-param>
       <param-name>heading</param-name>
       <param-value>component.acl.accesskey.frontend.title.main</param-value>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3811).

## Depends on

- MyCoRe PR https://github.com/MyCoRe-Org/mycore/pull/3112 (MCR-3811 Create mycore-vue module with shared toolchain and MCRVueRootServlet)

This PR must not be merged before the MyCoRe PR above is merged, otherwise the referenced class does not exist.

## What does this PR do?

`MCRVueRootServlet` was moved from `org.mycore.webtools.vue` to `org.mycore.frontend.vue` in MyCoRe and is now shipped by the new `mycore-vue` module. The `servlet-class` of the `AccessKeyManager` servlet in `mir-module/src/main/resources/META-INF/web-fragment.xml` is updated accordingly, which otherwise fails with a `ClassNotFoundException`.
