### PR TITLE
MCR-3807 Add missing comma / blank before Article Number in metadata …

### DIFF
--- a/mir-module/src/main/resources/xslt/modsmetadata.xsl
+++ b/mir-module/src/main/resources/xslt/modsmetadata.xsl
@@ -959,8 +959,10 @@
       </xsl:if>
       <!-- Articlenumber -->
       <xsl:if test="mods:part/mods:detail[@type='article_number']/mods:number">
-        <xsl:value-of
-          select="concat(mcri18n:translate('mir.articlenumber.short'),mods:part/mods:detail[@type='article_number']/mods:number)" />
+        <xsl:text>, </xsl:text>
+        <xsl:value-of select="concat(
+          mcri18n:translate('mir.articlenumber.short'), ' ', mods:part/mods:detail[@type='article_number']/mods:number
+        )" />
       </xsl:if>
       <!-- Pages -->
       <xsl:if test="mods:part/mods:extent[@unit='pages']">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3807).

`modsmetadata.xsl` was moved to `mycore-legacy` and has since been brought back into `mir`. Therefore, the corresponding adjustment for `mycore-mods` also needs to be made here explicitly (https://github.com/MyCoRe-Org/mycore/pull/3105).
