### PR TITLE
MIR-1668 Show the video frame image as player poster and search thumbnail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,13 @@ COPY --chown=root:root docker-entrypoint.sh /usr/local/bin/mir.sh
 RUN set -eux; \
     chmod 555 /usr/local/bin/mir.sh; \
 	apt-get update; \
-	apt-get install -y gosu curl; \
+	# ffmpeg and ffprobe are used by the video frame generator of MyCoRe
+	apt-get install -y gosu curl ffmpeg; \
 	rm -rf /var/lib/apt/lists/*;
 RUN chmod +x /usr/local/bin/mir.sh  && \
     rm -rf /usr/local/tomcat/webapps/* && \
+    # IIIF image identifiers carry the file path as an encoded solidus, the AJP connector below does the same
+    sed -ri "s|<Connector port=\"8080\" protocol=\"HTTP/1.1\"|<Connector port=\"8080\" protocol=\"HTTP/1.1\" encodedSolidusHandling=\"decode\"|" /usr/local/tomcat/conf/server.xml && \
     mkdir /opt/mir/ && \
     chown mcr:mcr -R /opt/mir/ && \
     sed -ri "s/<\/Service>/<Connector protocol=\"AJP\/1.3\" packetSize=\"$PACKET_SIZE\" maxParameterCount=\"$MAX_PARAMETER_COUNT\" maxPartCount=\"$MAX_PART_COUNT\" tomcatAuthentication=\"false\" scheme=\"https\" secretRequired=\"false\" allowedRequestAttributesPattern=\".*\" encodedSolidusHandling=\"decode\" address=\"0.0.0.0\" port=\"8009\" redirectPort=\"8443\" \/>&/g" /usr/local/tomcat/conf/server.xml

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ git submodule deinit --all
     `rngd -r /dev/urandom`
  1. Can't export using bibtex button on metadata page  
     install [bibutils](https://sourceforge.net/projects/bibutils/)
+ 1. Videos on the metadata page have no poster image  
+    install [FFmpeg](https://ffmpeg.org/), `ffmpeg` and `ffprobe` have to be on the `PATH`
  1. How can I use MyCoRe command line interface (not WebCLI)?  
     `mir-cli/target/appassembler/bin/mir.sh`  
     Set `JAVA_OPTS` environment variable to `-DMCR.DataPrefix=dev` before running.

--- a/mir-module/src/main/resources/META-INF/resources/js/mir/base.js
+++ b/mir-module/src/main/resources/META-INF/resources/js/mir/base.js
@@ -1,34 +1,42 @@
 (function ($) {
     $(document).ready(function () {
         const iiifSearchSelector = "data-iiif-jwt";
+        let iiifTokenRequest = null;
 
-        if ($("[" + iiifSearchSelector + "]").length > 0) {
-            $.ajax({
-                url: webApplicationBaseURL + "rsc/jwt",
-                type: "GET",
-                traditional: true,
-                dataType: "json",
-                success: function (data) {
-                    if (data.login_success) {
-                        loadImages(data);
-                    }
-                },
-                error: function (resp, title, message) {
-                    console.log(resp);
-                    console.log("Token request failed.");
-                }
-            });
+        // the token is requested at most once and shared by all IIIF images of the page
+        function getIiifToken() {
+            if (iiifTokenRequest === null) {
+                iiifTokenRequest = new Promise(function (resolve) {
+                    $.ajax({
+                        url: webApplicationBaseURL + "rsc/jwt",
+                        type: "GET",
+                        traditional: true,
+                        dataType: "json",
+                        success: function (data) {
+                            resolve(data.login_success ? data : null);
+                        },
+                        error: function (resp, title, message) {
+                            console.log(resp);
+                            console.log("Token request failed.");
+                            resolve(null);
+                        }
+                    });
+                });
+            }
+            return iiifTokenRequest;
         }
 
-        function loadImages(token) {
-            $("[" + iiifSearchSelector + "]").each(function (i, img) {
-                let url = img.getAttribute(iiifSearchSelector);
+        // loads an IIIF image with the token of the logged in user and passes a blob URL to the callback
+        function loadIiifImage(url, callback) {
+            getIiifToken().then(function (token) {
+                if (token === null) {
+                    return;
+                }
                 var xhr = new XMLHttpRequest();
                 xhr.onreadystatechange = function () {
                     if (this.readyState === 4 && this.status === 200) {
-                        //console.log(this.response, typeof this.response);
-                        var url = window.URL || window.webkitURL;
-                        img.src = url.createObjectURL(this.response);
+                        var urlFactory = window.URL || window.webkitURL;
+                        callback(urlFactory.createObjectURL(this.response));
                     }
                 }
                 xhr.open('GET', url);
@@ -37,6 +45,12 @@
                 xhr.send();
             });
         }
+
+        $("[" + iiifSearchSelector + "]").each(function (i, img) {
+            loadIiifImage(img.getAttribute(iiifSearchSelector), function (objectUrl) {
+                img.src = objectUrl;
+            });
+        });
 
         document.querySelectorAll(".personPopover, .boxPopover").forEach(function (popoverElement) {
             let id = popoverElement.getAttribute("id");
@@ -119,6 +133,52 @@
         };
 
         var sourceCache = {};
+        var posterCache = {};
+
+        // the iView image generated from a video frame is used as poster of the selected file
+        var applyPoster = function (player, currentOption) {
+            if (typeof player === "undefined") {
+                return;
+            }
+            var lookupKey = currentOption.parent().index() + "_" + currentOption.index();
+            // the poster is only applied once the image is known to load, otherwise a failing
+            // request would cover the video with an empty box instead of showing its first frame
+            var showPoster = function (url) {
+                // the image may have loaded after another file has been selected
+                if (videoChooserElement.find(":selected").is(currentOption)) {
+                    player.poster(url);
+                }
+            };
+
+            player.poster("");
+            // let the poster of the newly selected file reappear
+            player.hasStarted(false);
+
+            if (lookupKey in posterCache) {
+                showPoster(posterCache[lookupKey]);
+                return;
+            }
+
+            var poster = currentOption.attr("data-poster");
+            var posterJwt = currentOption.attr("data-poster-jwt");
+
+            if (typeof poster !== "undefined") {
+                var image = new Image();
+                image.onload = function () {
+                    posterCache[lookupKey] = poster;
+                    showPoster(poster);
+                };
+                image.onerror = function () {
+                    console.log("Could not load video poster " + poster);
+                };
+                image.src = poster;
+            } else if (typeof posterJwt !== "undefined") {
+                loadIiifImage(posterJwt, function (objectUrl) {
+                    posterCache[lookupKey] = objectUrl;
+                    showPoster(objectUrl);
+                });
+            }
+        };
 
         var getVideo = function (currentOption) {
             var src = currentOption.attr("data-src");
@@ -197,6 +257,10 @@
 
 
             playerToShow.src(sourceArr);
+
+            if (!isAudio) {
+                applyPoster(playerToShow, currentOption);
+            }
 
         });
 

--- a/mir-module/src/main/resources/config/mir/mycore.properties
+++ b/mir-module/src/main/resources/config/mir/mycore.properties
@@ -766,6 +766,8 @@ MIR.CanonicalBaseURL=
 ##############################################################################
 MIR.FileBrowser.FilesPerPage=10
 MIR.Thumbnail.IIIF.Resolution=!300,300
+# size of the iView image that is shown as poster of a video on the metadata page
+MIR.VideoPoster.IIIF.Resolution=!1280,720
 
 ##############################################################################
 # Open Policy Finder API (formerly Sherpa Romeo)                             #

--- a/mir-module/src/main/resources/xslt/metadata/mir-video.js.xsl
+++ b/mir-module/src/main/resources/xslt/metadata/mir-video.js.xsl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="3.0"
+  xmlns:mcracl="http://www.mycore.de/xslt/acl"
   xmlns:mcrderivate="http://www.mycore.de/xslt/derivate"
+  xmlns:mcriview2="http://www.mycore.de/xslt/iview2"
   xmlns:mcrmedia="http://www.mycore.de/xslt/media"
   xmlns:mcrsolr="http://www.mycore.de/xslt/solr"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -9,6 +11,7 @@
   <xsl:import href="xslImport:modsmeta:metadata/mir-video.js.xsl" />
 
   <xsl:param name="UserAgent" />
+  <xsl:param name="MIR.VideoPoster.IIIF.Resolution" select="'!1280,720'" />
 
   <xsl:template match="/">
     <!-- MIR-339 solr query if there is any "mp4" file in this object? -->
@@ -136,6 +139,10 @@
               <xsl:value-of select="concat(@type, ',', @src, ';')" />
             </xsl:for-each>
           </xsl:attribute>
+          <xsl:call-template name="addPosterAttribute">
+            <xsl:with-param name="derivateID" select="$derivateID" />
+            <xsl:with-param name="filePath" select="$filePath" />
+          </xsl:call-template>
           <xsl:value-of select="$fileName" />
         </option>
       </xsl:when>
@@ -147,5 +154,30 @@
         </option>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <!--
+    Adds the iView image that was generated from a video frame as player poster. The image is only requested if the
+    video file is already tiled. As the IIIF API does not share the session of the metadata page, logged in users
+    need a JWT, which the player script obtains before it loads the poster.
+  -->
+  <xsl:template name="addPosterAttribute">
+    <xsl:param name="derivateID" />
+    <xsl:param name="filePath" />
+
+    <xsl:if test="mcriview2:has-tiles($derivateID, concat('/', $filePath))">
+      <xsl:variable name="posterURL"
+        select="concat($WebApplicationBaseURL, 'api/iiif/image/v2/Iview/',
+          encode-for-uri(concat($derivateID, '/', $filePath)), '/full/',
+          $MIR.VideoPoster.IIIF.Resolution, '/0/default.jpg')" />
+      <xsl:choose>
+        <xsl:when test="mcracl:is-current-user-guest-user()">
+          <xsl:attribute name="data-poster" select="$posterURL" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="data-poster-jwt" select="$posterURL" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/mir-module/src/main/resources/xslt/response-mir.xsl
+++ b/mir-module/src/main/resources/xslt/response-mir.xsl
@@ -4,6 +4,7 @@
   xmlns:mcractionmapping="http://www.mycore.de/xslt/actionmapping"
   xmlns:mcrclassification="http://www.mycore.de/xslt/classification"
   xmlns:mcri18n="http://www.mycore.de/xslt/i18n"
+  xmlns:mcriview2="http://www.mycore.de/xslt/iview2"
   xmlns:mcrlayoututils="http://www.mycore.de/xslt/layoututils"
   xmlns:mcrurl="http://www.mycore.de/xslt/url"
   xmlns:mirorcidutil="http://www.mycore.de/xslt/mirorcidutil"
@@ -719,13 +720,19 @@
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="displayDerivate" select="$derivates[str[@name='id'] = $displayDerivateID]"/>
+            <xsl:variable name="displayMaindoc" select="string(($displayDerivate/str[@name='derivateMaindoc'])[1])"/>
+            <!-- files that iView does not support may still be tiled, e.g. a frame generated from a video -->
+            <xsl:variable name="displayHasTiles"
+              select="if (string-length($displayDerivateID) &gt; 0 and string-length($displayMaindoc) &gt; 0)
+                then mcriview2:has-tiles(string($displayDerivateID), concat('/', $displayMaindoc))
+                else false()"/>
 
             <!-- produces the thumbnail html-->
             <xsl:variable name="imageElement">
               <xsl:choose>
-                <!-- when the thumbnail derivate has pdf as maindoc or a iviewFile, then use the iiif api -->
+                <!-- when the thumbnail derivate has pdf as maindoc, a iviewFile or tiles, then use the iiif api -->
                 <xsl:when
-                        test="$displayDerivate/str[@name='iviewFile'] or translate(tokenize(string(($displayDerivate/str[@name='derivateMaindoc'])[1]), '\.')[last()],'PDF','pdf') = 'pdf'">
+                        test="$displayDerivate/str[@name='iviewFile'] or translate(tokenize($displayMaindoc, '\.')[last()],'PDF','pdf') = 'pdf' or $displayHasTiles">
                   <div class="hit_icon">
                     <img>
                       <xsl:variable name="hitIconSrc" select="concat($WebApplicationBaseURL, 'api/iiif/image/v2/thumbnail/', $identifier, '/full/', $MIR.Thumbnail.IIIF.Resolution, '/0/default.jpg')"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MIR-1668).

Requires MyCoRe-Org/mycore#3136, which tiles a frame of every video file. This PR consumes the resulting iView image.

## Metadata page (`mir-video.js.xsl`, `base.js`)

* every `mp4` option gets a poster URL of the `Iview` IIIF implementation, but only if `mcriview2:has-tiles` reports the file as tiled, so untiled videos cause no request
* the size is configurable via `MIR.VideoPoster.IIIF.Resolution` (default `!1280,720`)
* the IIIF API does not share the session of the metadata page, so logged in users load the poster through the JWT mechanism that already exists for `data-iiif-jwt`. Its token request and blob loading were extracted into reusable functions, the token is requested once per page
* the poster is applied only after the image has loaded. Otherwise a failed request leaves an empty black box over the video instead of its first frame

## Search result list (`response-mir.xsl`)

The IIIF branch was reached only for `iviewFile` or a PDF maindoc. Since `iviewFile` is indexed for image content types only, a tiled video never got a thumbnail although the `thumbnail` IIIF implementation serves it. The gate now also accepts a maindoc that has tiles. The check is last in the expression, so images and PDFs cost no additional file lookup.

## Docker

* installs `ffmpeg` via apt, next to the existing `gosu` and `curl`
* sets `encodedSolidusHandling="decode"` on the HTTP connector. The IIIF identifier carries the file path as an encoded solidus and Tomcat answers `400 Bad Request` by default. The AJP connector already had this setting

## README

FAQ entry that FFmpeg is required for video posters, next to the bibutils entry.

## Testing

1. build and deploy MyCoRe-Org/mycore#3136, FFmpeg and FFprobe have to be on the `PATH`
2. upload a video or run the derivate repair command for an existing one
3. the metadata page shows the generated frame as player poster, as guest and as logged in user
4. the search result list shows the same object with a thumbnail
